### PR TITLE
MWPW-147192 - card with old event hidden from Announcements

### DIFF
--- a/edsdme/blocks/announcements/AnnouncementsCards.js
+++ b/edsdme/blocks/announcements/AnnouncementsCards.js
@@ -29,16 +29,14 @@ export default class Announcements extends PartnerCards {
 
     this.allCards = this.allCards.filter((card) => {
       const isNeverExpires = card.tags.some((tag) => tag.id === 'caas:adobe-partners/collections/announcements/never-expires');
+      if (isNeverExpires) return !this.blockData.isArchive;
       const cardDate = new Date(card.cardDate);
-
+      const cardEndDate = card.endDate ? new Date(card.endDate) : null;
+      const now = Date.now();
       if (this.blockData.isArchive) {
-        if (isNeverExpires) return false;
-        if (cardDate <= startDate) return true;
-
-        const cardEndDate = card.endDate ? new Date(card.endDate) : null;
-        return cardEndDate && cardEndDate < Date.now();
+        return cardDate <= startDate || (cardEndDate && cardEndDate < now);
       }
-      return cardDate > startDate || isNeverExpires;
+      return cardEndDate ? cardDate > startDate && cardEndDate >= now : cardDate > startDate;
     });
 
     if (this.blockData.dateFilter) {


### PR DESCRIPTION
**Resolves**: [MWPW-147192](https://jira.corp.adobe.com/browse/MWPW-147192)

- if the card is not older then 180 days, but the eventEnd date is in the past, it will be displayed in Announcements archive and hidden from the Announcements component

**Quick summary:**
- Cards displayed in the **_Announcements archive_** are those not tagged with 'never-expires', and either older than 180 days or with an eventEnd date in the past.
- Cards displayed in **_Announcements_** are those tagged with 'never-expires', or not older than 180 days with an eventEnd date that is not in the past.


**LINKS:**

**Announcements:**
Before: https://stage--dme-partners--adobecom.hlx.live/channelpartners/drafts/kristijan/announcements
After: https://mwpw-147192-old-events-hidden-announce--dme-partners--adobecom.hlx.live/channelpartners/drafts/kristijan/announcements

**Announcements archive:**
Before: https://stage--dme-partners--adobecom.hlx.live/channelpartners/drafts/kristijan/announcements-archive
After: https://mwpw-147192-old-events-hidden-announce--dme-partners--adobecom.hlx.live/channelpartners/drafts/kristijan/announcements-archive