### PR TITLE
MWPW-153924: Implement logout logic

### DIFF
--- a/edsdme/scripts/scripts.js
+++ b/edsdme/scripts/scripts.js
@@ -1,4 +1,4 @@
-import { setLibs } from './utils.js';
+import { setLibs, redirectLoggedinPartner, updateIMSConfig } from './utils.js';
 
 // Add project-wide style path here.
 const STYLES = '';
@@ -72,6 +72,8 @@ const miloLibs = setLibs(LIBS);
 }());
 
 (async function loadPage() {
+  redirectLoggedinPartner();
+  updateIMSConfig();
   const { loadArea, setConfig } = await import(`${miloLibs}/utils/utils.js`);
 
   setConfig({ ...CONFIG, miloLibs });


### PR DESCRIPTION
Features:
- Added logout feature, logout redirect url is set based on `adobe-target-after-logout` meta tag, or is set to home page of the program if meta tag is not defined
- Moved `adobe-target-after-login` logic from runtime to MILO. Instead of defining this value in headers, now it will be defined in meta data of the page. If meta tag is defined, IMS will redirect user to that page after login, if it is not defined user will be redirected back to the page where he started the login process
- If `adobe-target-after-login` is defined and user is already logged in, user will be sent to the page that is defined in `adobe-target-after-login`

Resolves: [MWPW-153924](https://jira.corp.adobe.com/browse/MWPW-153924)

Test URLs:
- Before: https://stage--dme-partners--adobecom.hlx.page/channelpartners/drafts/ratko/test
- After: https://mwpw-153924-logout--dme-partners--adobecom.hlx.page/channelpartners/drafts/ratko/test