### PR TITLE
MWPW-155065 PartnerCards fallback for invalid thumbnail images

### DIFF
--- a/edsdme/components/NewsCard.js
+++ b/edsdme/components/NewsCard.js
@@ -1,8 +1,10 @@
 import { newsCardStyles } from './PartnerCardsStyles.js';
-import { formatDate, getLibs } from '../scripts/utils.js';
+import { formatDate, getLibs, prodHosts } from '../scripts/utils.js';
 
 const miloLibs = getLibs();
 const { html, LitElement } = await import(`${miloLibs}/deps/lit-all.min.js`);
+
+const DEFAULT_BACKGROUND_IMAGE_PATH = '/content/dam/solution/en/images/card-collection/sample_default.png';
 
 class NewsCard extends LitElement {
   static properties = { data: { type: Object } };
@@ -22,6 +24,26 @@ class NewsCard extends LitElement {
     newUrl.protocol = window.location.protocol;
     newUrl.host = window.location.host;
     return newUrl;
+  }
+
+  checkBackgroundImage(element) {
+    const style = window.getComputedStyle(element);
+    const url = style.backgroundImage.slice(5, -2);
+    const img = new Image();
+
+    const isProd = prodHosts.includes(window.location.host);
+    const defaultBackgroundImageOrigin = `https://solutionpartners.${isProd ? '' : 'stage2.'}adobe.com`;
+    const defaultBackgroundImageUrl = `${defaultBackgroundImageOrigin}${DEFAULT_BACKGROUND_IMAGE_PATH}`;
+
+    img.onerror = () => {
+      element.style.backgroundImage = `url(${defaultBackgroundImageUrl})`;
+    };
+
+    img.src = url;
+  }
+
+  firstUpdated() {
+    this.checkBackgroundImage(this.shadowRoot.querySelector('.card-header'));
   }
 
   render() {

--- a/edsdme/components/NewsCard.js
+++ b/edsdme/components/NewsCard.js
@@ -32,7 +32,7 @@ class NewsCard extends LitElement {
     const img = new Image();
 
     const isProd = prodHosts.includes(window.location.host);
-    const defaultBackgroundImageOrigin = `https://solutionpartners.${isProd ? '' : 'stage2.'}adobe.com`;
+    const defaultBackgroundImageOrigin = `https://partners.${isProd ? '' : 'stage.'}adobe.com`;
     const defaultBackgroundImageUrl = `${defaultBackgroundImageOrigin}${DEFAULT_BACKGROUND_IMAGE_PATH}`;
 
     img.onerror = () => {

--- a/edsdme/components/NewsCard.js
+++ b/edsdme/components/NewsCard.js
@@ -27,8 +27,7 @@ class NewsCard extends LitElement {
   }
 
   checkBackgroundImage(element) {
-    const style = window.getComputedStyle(element);
-    const url = style.backgroundImage.slice(5, -2);
+    const url = this.data.styles?.backgroundImage;
     const img = new Image();
 
     const isProd = prodHosts.includes(window.location.host);

--- a/edsdme/components/PartnerCardsStyles.js
+++ b/edsdme/components/PartnerCardsStyles.js
@@ -999,7 +999,7 @@ export const newsCardStyles = css`
   .news-card .card-header {
     min-height: 192px;
     max-height: 192px;
-    background-color: #323232;
+    background-color: #f5f5F5;
     background-repeat: no-repeat;
     background-position: 50% 50%;
     background-size: cover;

--- a/edsdme/components/PartnerCardsStyles.js
+++ b/edsdme/components/PartnerCardsStyles.js
@@ -999,7 +999,7 @@ export const newsCardStyles = css`
   .news-card .card-header {
     min-height: 192px;
     max-height: 192px;
-    background-color: #f5f5F5;
+    background-color: #323232;
     background-repeat: no-repeat;
     background-position: 50% 50%;
     background-size: cover;


### PR DESCRIPTION
- checks news card background image on first updated
- replace with a default image located at 
  - STAGE: https://partners.stage.adobe.com/content/dam/solution/en/images/card-collection/sample_default.png
  - PROD: https://partners.adobe.com/content/dam/solution/en/images/card-collection/sample_default.png

**Before:**
- https://stage--dme-partners--adobecom.hlx.page/channelpartners/drafts/dragana/announcements

**After:**
- https://mwpw-155065-invalid-thumbnail-fallback--dme-partners--adobecom.hlx.page/channelpartners/drafts/dragana/announcements