### PR TITLE
MWPW-156066 - do not display empty li el as sort/filter item

### DIFF
--- a/edsdme/components/PartnerCards.js
+++ b/edsdme/components/PartnerCards.js
@@ -85,7 +85,12 @@ export default class PartnerCards extends LitElement {
       filter: (cols) => {
         const [filterKeyEl, filterTagsKeysEl] = cols;
         const filterKey = filterKeyEl.innerText.trim().toLowerCase().replace(/ /g, '-');
-        const filterTagsKeys = Array.from(filterTagsKeysEl.querySelectorAll('li'), (li) => li.innerText.trim().toLowerCase().replace(/ /g, '-'));
+
+        const filterTagsKeys = [];
+        filterTagsKeysEl.querySelectorAll('li').forEach((li) => {
+          const key = li.innerText.trim().toLowerCase().replace(/ /g, '-');
+          if (key !== '') filterTagsKeys.push(key);
+        });
 
         if (!filterKey || !filterTagsKeys.length) return;
 
@@ -103,7 +108,12 @@ export default class PartnerCards extends LitElement {
       },
       sort: (cols) => {
         const [sortKeysEl] = cols;
-        const sortKeys = Array.from(sortKeysEl.querySelectorAll('li'), (li) => li.innerText.trim().toLowerCase().replace(/ /g, '-'));
+
+        const sortKeys = [];
+        sortKeysEl.querySelectorAll('li').forEach((li) => {
+          const key = li.innerText.trim().toLowerCase().replace(/ /g, '-');
+          if (key !== '') sortKeys.push(key);
+        });
 
         if (!sortKeys.length) return;
 


### PR DESCRIPTION
**Resolves:** [MWPW-156066](https://jira.corp.adobe.com/browse/MWPW-156066)

- PR for not displaying empty elements when for filters/sort items are authored empty bullets

**LINKS:**
**Before:** https://stage--dme-partners--adobecom.hlx.page/channelpartners/drafts/kristijan/announcements-author-test
**After:** https://mwpw-156066-authored-empty-li--dme-partners--adobecom.hlx.page/channelpartners/drafts/kristijan/announcements-author-test