### PR TITLE
MWPW-154151 announcement template date block

### DIFF
--- a/edsdme/blocks/announcement-date/announcement-date.css
+++ b/edsdme/blocks/announcement-date/announcement-date.css
@@ -1,0 +1,4 @@
+.announcement-date {
+  display: block;
+  margin: 24px 0 32px;
+}

--- a/edsdme/blocks/announcement-date/announcement-date.js
+++ b/edsdme/blocks/announcement-date/announcement-date.js
@@ -1,0 +1,33 @@
+import { formatDate } from '../../scripts/utils.js';
+import { createTag } from '../utils/utils.js';
+
+const CARD_METADATA_PROPERTY_CREATED = 'created';
+
+export default async function init(el) {
+  performance.mark('announcement-date:start');
+
+  let createdDateValue;
+  const cardMetadataEl = document.querySelector('.card-metadata');
+
+  if (cardMetadataEl) {
+    [...cardMetadataEl.children].forEach((row) => {
+      const firstColumn = row.children[0];
+      if (firstColumn && firstColumn.innerText.trim().toLowerCase() === CARD_METADATA_PROPERTY_CREATED) {
+        createdDateValue = row.children[1]?.innerText.trim();
+      }
+    });
+  }
+
+  const createdDate = new Date(createdDateValue);
+
+  if (!isNaN(createdDate)) {
+    el.innerHTML = '';
+    el.className = `announcement-date-wrapper content ${el.className}`;
+    el.classList.remove('announcement-date');
+    const dateEl = createTag('time', { datetime: createdDate.toISOString(), class: 'announcement-date detail-m' }, formatDate(createdDateValue));
+    el.append(dateEl);
+  }
+
+  performance.mark('announcement-date:end');
+  performance.measure('announcement-date block', 'announcement-date:start', 'announcement-date:end');
+}

--- a/edsdme/blocks/announcement-date/announcement-date.js
+++ b/edsdme/blocks/announcement-date/announcement-date.js
@@ -19,9 +19,9 @@ export default async function init(el) {
   }
 
   const createdDate = new Date(createdDateValue);
-  const locale = getLocale();
 
   if (!isNaN(createdDate)) {
+    const locale = getLocale();
     el.innerHTML = '';
     el.className = `announcement-date-wrapper content ${el.className}`;
     el.classList.remove('announcement-date');

--- a/edsdme/blocks/announcement-date/announcement-date.js
+++ b/edsdme/blocks/announcement-date/announcement-date.js
@@ -25,7 +25,10 @@ export default async function init(el) {
     el.innerHTML = '';
     el.className = `announcement-date-wrapper content ${el.className}`;
     el.classList.remove('announcement-date');
-    const dateEl = createTag('time', { datetime: createdDate.toISOString(), class: 'announcement-date detail-m' }, formatDate(createdDateValue, locale.ietf));
+    const month = String(createdDate.getMonth() + 1).padStart(2, '0');
+    const day = String(createdDate.getDate()).padStart(2, '0');
+    const datetime = `${createdDate.getFullYear()}-${month}-${day}`;
+    const dateEl = createTag('time', { datetime, class: 'announcement-date detail-m' }, formatDate(createdDateValue, locale.ietf));
     el.append(dateEl);
   }
 

--- a/edsdme/blocks/announcement-date/announcement-date.js
+++ b/edsdme/blocks/announcement-date/announcement-date.js
@@ -1,4 +1,4 @@
-import { formatDate } from '../../scripts/utils.js';
+import { formatDate, getLocale } from '../../scripts/utils.js';
 import { createTag } from '../utils/utils.js';
 
 const CARD_METADATA_PROPERTY_CREATED = 'created';
@@ -19,12 +19,13 @@ export default async function init(el) {
   }
 
   const createdDate = new Date(createdDateValue);
+  const locale = getLocale();
 
   if (!isNaN(createdDate)) {
     el.innerHTML = '';
     el.className = `announcement-date-wrapper content ${el.className}`;
     el.classList.remove('announcement-date');
-    const dateEl = createTag('time', { datetime: createdDate.toISOString(), class: 'announcement-date detail-m' }, formatDate(createdDateValue));
+    const dateEl = createTag('time', { datetime: createdDate.toISOString(), class: 'announcement-date detail-m' }, formatDate(createdDateValue, locale.ietf));
     el.append(dateEl);
   }
 

--- a/edsdme/blocks/announcements/announcements.js
+++ b/edsdme/blocks/announcements/announcements.js
@@ -86,6 +86,7 @@ export default async function init(el) {
     pagination: 'load-more',
     isArchive,
     caasUrl: getCaasUrl(block),
+    ietf: config.locale.ietf,
   };
 
   const app = document.createElement('announcements-cards');

--- a/edsdme/blocks/search/SearchCards.js
+++ b/edsdme/blocks/search/SearchCards.js
@@ -40,7 +40,7 @@ export default class Search extends PartnerCards {
       return html`${repeat(
         this.paginatedCards,
         (card) => card.id,
-        (card) => html`<search-card class="card-wrapper" .data=${card} .localizedText="${this.blockData.localizedText} .ietf=${this.blockData.ietf}></search-card>`,
+        (card) => html`<search-card class="card-wrapper" .data=${card} .localizedText=${this.blockData.localizedText} .ietf=${this.blockData.ietf}></search-card>`,
       )}`;
     }
     return html`<div class="no-results">

--- a/edsdme/blocks/search/SearchCards.js
+++ b/edsdme/blocks/search/SearchCards.js
@@ -40,7 +40,7 @@ export default class Search extends PartnerCards {
       return html`${repeat(
         this.paginatedCards,
         (card) => card.id,
-        (card) => html`<search-card class="card-wrapper" .data=${card} .localizedText="${this.blockData.localizedText}"></search-card>`,
+        (card) => html`<search-card class="card-wrapper" .data=${card} .localizedText="${this.blockData.localizedText} .ietf=${this.blockData.ietf}"></search-card>`,
       )}`;
     }
     return html`<div class="no-results">

--- a/edsdme/blocks/search/SearchCards.js
+++ b/edsdme/blocks/search/SearchCards.js
@@ -40,7 +40,7 @@ export default class Search extends PartnerCards {
       return html`${repeat(
         this.paginatedCards,
         (card) => card.id,
-        (card) => html`<search-card class="card-wrapper" .data=${card} .localizedText="${this.blockData.localizedText} .ietf=${this.blockData.ietf}"></search-card>`,
+        (card) => html`<search-card class="card-wrapper" .data=${card} .localizedText="${this.blockData.localizedText} .ietf=${this.blockData.ietf}></search-card>`,
       )}`;
     }
     return html`<div class="no-results">

--- a/edsdme/components/PartnerCards.js
+++ b/edsdme/components/PartnerCards.js
@@ -229,7 +229,7 @@ export default class PartnerCards extends LitElement {
       return html`${repeat(
         this.paginatedCards,
         (card) => card.id,
-        (card) => html`<single-partner-card class="card-wrapper" .data=${card}></signle-partner-card>`,
+        (card) => html`<single-partner-card class="card-wrapper" .data=${card} .ietf=${this.blockData.ietf}></single-partner-card>`,
       )}`;
     }
 

--- a/edsdme/components/SearchCard.js
+++ b/edsdme/components/SearchCard.js
@@ -1,7 +1,8 @@
 import { searchCardStyles } from './SearchCardStyles.js';
-import { formatDate, getLibs } from '../scripts/utils.js';
+import { formatDate, getLibs, getLocale } from '../scripts/utils.js';
 
 const miloLibs = getLibs();
+const locale = getLocale();
 const { html, repeat, LitElement } = await import(`${miloLibs}/deps/lit-all.min.js`);
 
 class SearchCard extends LitElement {
@@ -64,7 +65,7 @@ class SearchCard extends LitElement {
             : ''
           }
           <div class="card-text">
-            <span class="card-date">${this.localizedText['{{last-modified}}']}: ${formatDate(this.data.cardDate)}
+            <span class="card-date">${this.localizedText['{{last-modified}}']}: ${formatDate(this.data.cardDate, locale.ietf)}
               <span class="card-size">${this.localizedText['{{size}}']}: ${this.data.contentArea?.size}</span>
             </span>
             <p class="card-description">${this.data.contentArea?.description}</p>

--- a/edsdme/components/SearchCard.js
+++ b/edsdme/components/SearchCard.js
@@ -1,14 +1,14 @@
 import { searchCardStyles } from './SearchCardStyles.js';
-import { formatDate, getLibs, getLocale } from '../scripts/utils.js';
+import { formatDate, getLibs } from '../scripts/utils.js';
 
 const miloLibs = getLibs();
-const locale = getLocale();
 const { html, repeat, LitElement } = await import(`${miloLibs}/deps/lit-all.min.js`);
 
 class SearchCard extends LitElement {
   static properties = {
     data: { type: Object },
     localizedText: { type: Object },
+    ietf: { type: String },
   };
 
   static styles = searchCardStyles;
@@ -65,7 +65,7 @@ class SearchCard extends LitElement {
             : ''
           }
           <div class="card-text">
-            <span class="card-date">${this.localizedText['{{last-modified}}']}: ${formatDate(this.data.cardDate, locale.ietf)}
+            <span class="card-date">${this.localizedText['{{last-modified}}']}: ${formatDate(this.data.cardDate, this.ietf)}
               <span class="card-size">${this.localizedText['{{size}}']}: ${this.data.contentArea?.size}</span>
             </span>
             <p class="card-description">${this.data.contentArea?.description}</p>

--- a/edsdme/components/SinglePartnerCard.js
+++ b/edsdme/components/SinglePartnerCard.js
@@ -1,7 +1,8 @@
 import { singlePartnerCardStyles } from './PartnerCardsStyles.js';
-import { formatDate, getLibs, prodHosts } from '../scripts/utils.js';
+import { formatDate, getLibs, getLocale, prodHosts } from '../scripts/utils.js';
 
 const miloLibs = getLibs();
+const locale = getLocale();
 const { html, LitElement } = await import(`${miloLibs}/deps/lit-all.min.js`);
 
 const DEFAULT_BACKGROUND_IMAGE_PATH = '/content/dam/solution/en/images/card-collection/sample_default.png';
@@ -59,7 +60,7 @@ class SinglePartnerCard extends LitElement {
             <p class="card-description">${this.data.contentArea?.description}</p>
           </div>
           <div class="card-footer">
-            <span class="card-date">${formatDate(this.data.cardDate)}</span>
+            <span class="card-date">${formatDate(this.data.cardDate, locale.ietf)}</span>
             <a class="card-btn" href="${this.transformCardUrl(this.data.contentArea?.url)}">${this.data.footer[0]?.right[0]?.text}</a>
           </div>
         </div>

--- a/edsdme/components/SinglePartnerCard.js
+++ b/edsdme/components/SinglePartnerCard.js
@@ -1,14 +1,16 @@
 import { singlePartnerCardStyles } from './PartnerCardsStyles.js';
-import { formatDate, getLibs, getLocale, prodHosts } from '../scripts/utils.js';
+import { formatDate, getLibs, prodHosts } from '../scripts/utils.js';
 
 const miloLibs = getLibs();
-const locale = getLocale();
 const { html, LitElement } = await import(`${miloLibs}/deps/lit-all.min.js`);
 
 const DEFAULT_BACKGROUND_IMAGE_PATH = '/content/dam/solution/en/images/card-collection/sample_default.png';
 
 class SinglePartnerCard extends LitElement {
-  static properties = { data: { type: Object } };
+  static properties = {
+    data: { type: Object },
+    ietf: { type: String },
+  };
 
   static styles = singlePartnerCardStyles;
 
@@ -60,7 +62,7 @@ class SinglePartnerCard extends LitElement {
             <p class="card-description">${this.data.contentArea?.description}</p>
           </div>
           <div class="card-footer">
-            <span class="card-date">${formatDate(this.data.cardDate, locale.ietf)}</span>
+            <span class="card-date">${formatDate(this.data.cardDate, this.ietf)}</span>
             <a class="card-btn" href="${this.transformCardUrl(this.data.contentArea?.url)}">${this.data.footer[0]?.right[0]?.text}</a>
           </div>
         </div>

--- a/edsdme/scripts/utils.js
+++ b/edsdme/scripts/utils.js
@@ -55,7 +55,7 @@ export const prodHosts = [
  * ------------------------------------------------------------
  */
 
-export function formatDate(cardDate) {
+export function formatDate(cardDate, locale = 'en-US') {
   if (!cardDate) return;
 
   const dateObject = new Date(cardDate);
@@ -65,7 +65,7 @@ export function formatDate(cardDate) {
     day: 'numeric',
   };
 
-  const formattedDate = dateObject.toLocaleString('en-US', options);
+  const formattedDate = dateObject.toLocaleString(locale, options);
   // eslint-disable-next-line consistent-return
   return formattedDate;
 }
@@ -134,7 +134,7 @@ export function signedInNonMember() {
   return partnerIsSignedIn() && !isMember();
 }
 
-export function isReseller (level) {
+export function isReseller(level) {
   return RESSELER_LEVELS.includes(level?.toLowerCase());
 }
 

--- a/edsdme/styles/styles.css
+++ b/edsdme/styles/styles.css
@@ -40,3 +40,8 @@
 .personalization-hide {
   display: none;
 }
+
+/* announcement title section divider */
+.announcement-title.section.divider {
+  border-bottom: 1px solid rgb(109 109 109);
+}

--- a/test/blocks/announcement-date/announcement-date.test.js
+++ b/test/blocks/announcement-date/announcement-date.test.js
@@ -12,7 +12,7 @@ describe('announcement date block', () => {
   it('should display the expected date', async () => {
     const announcementDate = document.querySelector('time.announcement-date');
     expect(announcementDate).to.exist;
-    expect(announcementDate.getAttribute('datetime')).to.equal('2024-01-01T23:00:00.000Z');
+    expect(announcementDate.getAttribute('datetime')).to.equal('2024-01-02');
     expect(announcementDate.innerText).to.equal('Jan 2, 2024');
   });
 

--- a/test/blocks/announcement-date/announcement-date.test.js
+++ b/test/blocks/announcement-date/announcement-date.test.js
@@ -1,0 +1,25 @@
+import { readFile } from '@web/test-runner-commands';
+import { expect } from '@esm-bundle/chai';
+
+describe('announcement date block', () => {
+  before(async () => {
+    const module = await import('../../../edsdme/blocks/announcement-date/announcement-date.js');
+    document.head.innerHTML = await readFile({ path: './mocks/body.html' });
+    const announcementDateBlock = document.querySelector('.announcement-date');
+    await module.default(announcementDateBlock);
+  });
+
+  it('should display the expected date', async () => {
+    const announcementDate = document.querySelector('time.announcement-date');
+    expect(announcementDate).to.exist;
+    expect(announcementDate.getAttribute('datetime')).to.equal('2024-01-01T23:00:00.000Z');
+    expect(announcementDate.innerText).to.equal('Jan 2, 2024');
+  });
+
+  it('should render inside a wrapper element', async () => {
+    const announcementDateWrapper = document.querySelector('.announcement-date-wrapper');
+    const announcementDate = announcementDateWrapper.querySelector('time.announcement-date');
+    expect(announcementDateWrapper).to.exist;
+    expect(announcementDate).to.exist;
+  });
+});

--- a/test/blocks/announcement-date/mocks/body.html
+++ b/test/blocks/announcement-date/mocks/body.html
@@ -1,0 +1,38 @@
+<div>
+  <div class="announcement-date"></div>
+  <div class="card-metadata">
+    <div>
+      <div data-valign="middle">CardTitle</div>
+      <div data-valign="middle">Announcement Card Title</div>
+    </div>
+    <div>
+      <div data-valign="middle">CardDescription</div>
+      <div data-valign="middle">Announcement Card Description</div>
+    </div>
+    <div>
+      <div data-valign="middle">ContentType</div>
+      <div data-valign="middle">article</div>
+    </div>
+    <div>
+      <div data-valign="middle">Tags</div>
+      <div data-valign="middle">CPP,caas:adobe-partners/collections/announcements,
+        caas:adobe-partners/cpp/partner-level/public,caas:adobe-partners/cpp/region/worldwide</div>
+    </div>
+    <div>
+      <div data-valign="middle">Details</div>
+      <div data-valign="middle"></div>
+    </div>
+    <div>
+      <div data-valign="middle">cta1Text</div>
+      <div data-valign="middle">Read More</div>
+    </div>
+    <div>
+      <div data-valign="middle">Created</div>
+      <div data-valign="middle">01/02/2024</div>
+    </div>
+    <div>
+      <div data-valign="middle">EventEnd</div>
+      <div data-valign="middle"></div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
[MWPW-154151](https://jira.corp.adobe.com/browse/MWPW-154151)

- adds an announcement date block that reads the created date of the card metadata if present and displays it
- adds an `announcement-title` style for the divider
- adds localization in date formatting utility and updates references
- adds unit tests

**LINKS:**
- **Before**: https://stage--dme-partners--adobecom.hlx.page/channelpartners/drafts/richard/announcements-template?georouting=off
- **After**: https://mwpw-153151-announcement-date--dme-partners--adobecom.hlx.page/channelpartners/drafts/richard/announcements-template?georouting=off