### PR TITLE
MWPW-154151 announcement template back button

### DIFF
--- a/edsdme/blocks/announcement-date/announcement-date.css
+++ b/edsdme/blocks/announcement-date/announcement-date.css
@@ -1,4 +1,5 @@
 .announcement-date {
   display: block;
-  margin: var(--spacing-s) 0 var(--spacing-m);
+  padding: var(--spacing-s) 0;
+  border-top: 1px solid var(--color-gray-600);
 }

--- a/edsdme/blocks/announcement-date/announcement-date.css
+++ b/edsdme/blocks/announcement-date/announcement-date.css
@@ -1,4 +1,4 @@
 .announcement-date {
   display: block;
-  margin: 24px 0 32px;
+  margin: var(--spacing-s) 0 var(--spacing-m);
 }

--- a/edsdme/styles/styles.css
+++ b/edsdme/styles/styles.css
@@ -45,11 +45,3 @@
 .announcement-title.section.divider {
   border-bottom: 1px solid var(--color-gray-600);
 }
-
-.announcement-back-button {
-  margin: var(--spacing-m) 0;
-}
-
-.announcement-back-button .action-area {
-  justify-content: flex-end;
-}

--- a/edsdme/styles/styles.css
+++ b/edsdme/styles/styles.css
@@ -40,8 +40,3 @@
 .personalization-hide {
   display: none;
 }
-
-/* announcement template */
-.announcement-title.section.divider {
-  border-bottom: 1px solid var(--color-gray-600);
-}

--- a/edsdme/styles/styles.css
+++ b/edsdme/styles/styles.css
@@ -41,7 +41,15 @@
   display: none;
 }
 
-/* announcement title section divider */
+/* announcement template */
 .announcement-title.section.divider {
-  border-bottom: 1px solid rgb(109 109 109);
+  border-bottom: 1px solid var(--color-gray-600);
+}
+
+.announcement-back-button {
+  margin: var(--spacing-m) 0;
+}
+
+.announcement-back-button .action-area {
+  justify-content: flex-end;
 }


### PR DESCRIPTION
ticket: https://jira.corp.adobe.com/browse/MWPW-154151
design: https://xd.adobe.com/view/125460f4-a964-49d0-9571-c08ae19e77fe-4707/screen/2e2c842b-f904-4ee5-8622-4f80dddf3e04

- moves line rendering to announcement date for simplified authoring
- uses css variables
- authoring proposal for the announcement back button is in the [announcement template document](https://adobe.sharepoint.com/:w:/r/sites/AdobePartnerConnectionAPC35/_layouts/15/Doc.aspx?sourcedoc=%7BAED2930A-DBD2-4C64-A1FB-D903B5F315D1%7D&file=announcements-template.docx&action=default&mobileredirect=true)
- icon currently missing since it needs adding in Milo

**LINKS:**
- **Before**: https://stage--dme-partners--adobecom.hlx.page/channelpartners/drafts/richard/announcements-template?georouting=off
- **After**: https://mwpw-14151-announcement-back--dme-partners--adobecom.hlx.page/channelpartners/drafts/richard/announcements-template?georouting=off