### PR TITLE
MWPW-159126: Load gnav/footer based on locale

### DIFF
--- a/edsdme/scripts/utils.js
+++ b/edsdme/scripts/utils.js
@@ -401,21 +401,25 @@ export async function preloadResources(locales, miloLibs) {
 }
 
 export function updateNavigation(locales) {
-  const { prefix } = getLocale(locales);
   const gnavMeta = getMetadata('gnav-source');
-  if (!gnavMeta || !isMember()) return;
-
-  const gnavLoggedIn = getMetadataContent('gnav-loggedin-source');
-  gnavMeta.content = gnavLoggedIn ?? `${prefix}/edsdme/partners-shared/loggedin-gnav`;
+  if (!gnavMeta) return;
+  const { prefix } = getLocale(locales);
+  let { content } = gnavMeta;
+  if (isMember()) {
+    content = getMetadataContent('gnav-loggedin-source') ?? `${prefix}/edsdme/partners-shared/loggedin-gnav`
+  }
+  gnavMeta.content = content.startsWith('/edsdme') ? prefix + content : content;
 }
 
 export function updateFooter(locales) {
-  const { prefix } = getLocale(locales);
   const footerMeta = getMetadata('footer-source');
-  if (!footerMeta || !isMember()) return;
-
-  const footerLoggedIn = getMetadataContent('footer-loggedin-source');
-  footerMeta.content = footerLoggedIn ?? `${prefix}/edsdme/partners-shared/loggedin-footer`;
+  if (!footerMeta) return;
+  const { prefix } = getLocale(locales);
+  let { content } = footerMeta;
+  if (isMember()) {
+    content = getMetadataContent('footer-loggedin-source') ??  `${prefix}/edsdme/partners-shared/loggedin-footer`;
+  }
+  footerMeta.content = content.startsWith('/edsdme') ? prefix + content : content;
 }
 
 export function getNodesByXPath(query, context = document) {

--- a/edsdme/scripts/utils.js
+++ b/edsdme/scripts/utils.js
@@ -409,7 +409,7 @@ export function updateNavigation(locales) {
   const { prefix } = getLocale(locales);
   let { content } = gnavMeta;
   if (isMember()) {
-    content = getMetadataContent('gnav-loggedin-source') ?? `${prefix}/edsdme/partners-shared/loggedin-gnav`
+    content = getMetadataContent('gnav-loggedin-source') ?? `${prefix}/edsdme/partners-shared/loggedin-gnav`;
   }
   gnavMeta.content = content.startsWith('/edsdme') ? prefix + content : content;
 }
@@ -420,7 +420,7 @@ export function updateFooter(locales) {
   const { prefix } = getLocale(locales);
   let { content } = footerMeta;
   if (isMember()) {
-    content = getMetadataContent('footer-loggedin-source') ??  `${prefix}/edsdme/partners-shared/loggedin-footer`;
+    content = getMetadataContent('footer-loggedin-source') ?? `${prefix}/edsdme/partners-shared/loggedin-footer`;
   }
   footerMeta.content = content.startsWith('/edsdme') ? prefix + content : content;
 }

--- a/test/scripts/utils.jest.js
+++ b/test/scripts/utils.jest.js
@@ -92,6 +92,24 @@ describe('Test utils.js', () => {
       const protectedFooterPath = document.querySelector('meta[name="footer-loggedin-source"]')?.content;
       expect(footerPathModified).toEqual(protectedFooterPath);
     });
+    it('Public footer is fetched based on locale', async () => {
+      const cookieObject = {
+        CPP: {
+          status: 'NOT_MEMBER',
+        }
+      };
+      document.cookie = `partner_data=${JSON.stringify(cookieObject)}`;
+      window.location.pathname = '/de/channelpartners/';
+      const locales = {
+        '': { ietf: 'en-US', tk: 'hah7vzn.css' },
+        de: { ietf: 'de-DE', tk: 'hah7vzn.css' },
+      };
+      const footerPath = document.querySelector('meta[name="footer-source"]')?.content;
+      updateFooter(locales);
+      const footerPathModified = document.querySelector('meta[name="footer-source"]')?.content;
+      expect(footerPath).not.toEqual(footerPathModified);
+      expect(footerPathModified).toEqual('/de/edsdme/partners-shared/footer');
+    });
     it('Protected footer is fetched based on locale if footer-loggeding-source metadata is not present', async () => {
       const cookieObject = {
         CPP: {
@@ -146,7 +164,25 @@ describe('Test utils.js', () => {
       const protectedGnavPath = document.querySelector('meta[name="gnav-loggedin-source"]')?.content;
       expect(gnavPathModified).toEqual(protectedGnavPath);
     });
-    it('Protected footer is fetched based on locale if gnav-loggeding-source metadata is not present', async () => {
+    it('Public gnav is fetched based on locale', async () => {
+      const cookieObject = {
+        CPP: {
+          status: 'NOT_MEMBER',
+        }
+      };
+      document.cookie = `partner_data=${JSON.stringify(cookieObject)}`;
+      window.location.pathname = '/de/channelpartners/';
+      const locales = {
+        '': { ietf: 'en-US', tk: 'hah7vzn.css' },
+        de: { ietf: 'de-DE', tk: 'hah7vzn.css' },
+      };
+      const gnavPath = document.querySelector('meta[name="gnav-source"]')?.content;
+      updateNavigation(locales);
+      const gnavPathModified = document.querySelector('meta[name="gnav-source"]')?.content;
+      expect(gnavPath).not.toEqual(gnavPathModified);
+      expect(gnavPathModified).toEqual('/de/edsdme/partners-shared/public-gnav');
+    });
+    it('Protected gnav is fetched based on locale if gnav-loggeding-source metadata is not present', async () => {
       const cookieObject = {
         CPP: {
           status: 'MEMBER',

--- a/test/scripts/utils.jest.js
+++ b/test/scripts/utils.jest.js
@@ -87,11 +87,7 @@ describe('Test utils.js', () => {
       expect(footerPathModified).toEqual(protectedFooterPath);
     });
     it('Public footer is fetched based on locale', async () => {
-      const cookieObject = {
-        CPP: {
-          status: 'NOT_MEMBER',
-        }
-      };
+      const cookieObject = { CPP: { status: 'NOT_MEMBER' } };
       document.cookie = `partner_data=${JSON.stringify(cookieObject)}`;
       window.location.pathname = '/de/channelpartners/';
       const locales = {
@@ -147,11 +143,7 @@ describe('Test utils.js', () => {
       expect(gnavPathModified).toEqual(protectedGnavPath);
     });
     it('Public gnav is fetched based on locale', async () => {
-      const cookieObject = {
-        CPP: {
-          status: 'NOT_MEMBER',
-        }
-      };
+      const cookieObject = { CPP: { status: 'NOT_MEMBER' } };
       document.cookie = `partner_data=${JSON.stringify(cookieObject)}`;
       window.location.pathname = '/de/channelpartners/';
       const locales = {
@@ -165,11 +157,7 @@ describe('Test utils.js', () => {
       expect(gnavPathModified).toEqual('/de/edsdme/partners-shared/public-gnav');
     });
     it('Protected gnav is fetched based on locale if gnav-loggeding-source metadata is not present', async () => {
-      const cookieObject = {
-        CPP: {
-          status: 'MEMBER',
-        }
-      };
+      const cookieObject = { CPP: { status: 'MEMBER' } };
       document.cookie = `partner_data=${JSON.stringify(cookieObject)}`;
       window.location.pathname = '/de/channelpartners/';
       const locales = {


### PR DESCRIPTION
- Load gnav/footer with locale prefix if metadata is authored without locale (eg. `/edsdme/partners-shared/footer`)

Resolves: [MWPW-159126](https://jira.corp.adobe.com/browse/MWPW-159126)

Before: https://stage--dme-partners--adobecom.hlx.page/de/channelpartners/drafts/ratko/test
After: https://mwpw-159126-gnav-footer-locale--dme-partners--adobecom.hlx.page/de/channelpartners/drafts/ratko/test