### PR TITLE
Fix nala action

### DIFF
--- a/.github/workflows/run-nala-on-dme.yml
+++ b/.github/workflows/run-nala-on-dme.yml
@@ -2,19 +2,21 @@ name: DME-Partners Nala Tests
 
 on:
   pull_request:
-    types: [ opened, synchronize, reopened ]
+    types: [ labeled, synchronize, reopened ]
 
 jobs:
   action:
     name: Running E2E & IT
-    if: contains(github.event.pull_request.labels.*.name, 'run-on-dme')
+    if: or(
+      equal(github.event.label.name, 'run-on-dme'),
+      and(equal(github.event.action, 'synchronize'), contains(join(github.event.pull_request.labels.*.name, ','), 'run-on-dme')),
+      and(equal(github.event.action, 'reopened'), contains(join(github.event.pull_request.labels.*.name, ','), 'run-on-dme'))
+      )
     runs-on: ubuntu-latest
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
-      - name: Display run number
-        run: echo "This is run number $GITHUB_RUN_NUMBER"
       # - name: Run Nala
       #   uses: adobecom/dme-partners@stage # Change if doing dev work
       #   env:

--- a/.github/workflows/run-nala-on-dme.yml
+++ b/.github/workflows/run-nala-on-dme.yml
@@ -2,8 +2,7 @@ name: DME-Partners Nala Tests
 
 on:
   pull_request:
-    #test
-    types: [ labeled, opened, synchronize, reopened ]
+    types: [ opened, synchronize, reopened ]
 
 jobs:
   action:
@@ -14,17 +13,19 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
-      - name: Run Nala
-        uses: adobecom/dme-partners@stage # Change if doing dev work
-        env:
-          labels: ${{ join(github.event.pull_request.labels.*.name, ' ') }}
-          branch: ${{ github.event.pull_request.head.ref }}
-          repoName: ${{ github.repository }}
-          prUrl: ${{ github.event.pull_request.head.repo.html_url }}
-          prOrg: ${{ github.event.pull_request.head.repo.owner.login }}
-          prRepo: ${{ github.event.pull_request.head.repo.name }}
-          prBranch: ${{ github.event.pull_request.head.ref }}
-          prBaseBranch: ${{ github.event.pull_request.base.ref }}
-          IMS_EMAIL: ${{ secrets.IMS_EMAIL }}
-          IMS_PASS: ${{ secrets.IMS_PASS }}
-          HLX_API_KEY: ${{ secrets.HLX_API_KEY }}
+      - name: Display run number
+        run: echo "This is run number $GITHUB_RUN_NUMBER"
+      # - name: Run Nala
+      #   uses: adobecom/dme-partners@stage # Change if doing dev work
+      #   env:
+      #     labels: ${{ join(github.event.pull_request.labels.*.name, ' ') }}
+      #     branch: ${{ github.event.pull_request.head.ref }}
+      #     repoName: ${{ github.repository }}
+      #     prUrl: ${{ github.event.pull_request.head.repo.html_url }}
+      #     prOrg: ${{ github.event.pull_request.head.repo.owner.login }}
+      #     prRepo: ${{ github.event.pull_request.head.repo.name }}
+      #     prBranch: ${{ github.event.pull_request.head.ref }}
+      #     prBaseBranch: ${{ github.event.pull_request.base.ref }}
+      #     IMS_EMAIL: ${{ secrets.IMS_EMAIL }}
+      #     IMS_PASS: ${{ secrets.IMS_PASS }}
+      #     HLX_API_KEY: ${{ secrets.HLX_API_KEY }}

--- a/.github/workflows/run-nala-on-dme.yml
+++ b/.github/workflows/run-nala-on-dme.yml
@@ -2,6 +2,7 @@ name: DME-Partners Nala Tests
 
 on:
   pull_request:
+    #test
     types: [ labeled, opened, synchronize, reopened ]
 
 jobs:

--- a/.github/workflows/run-nala-on-dme.yml
+++ b/.github/workflows/run-nala-on-dme.yml
@@ -10,23 +10,22 @@ jobs:
     if: github.event.label.name == 'run-on-dme'
       || (github.event.action == 'synchronize' && contains(join(github.event.pull_request.labels.*.name, ','), 'run-on-dme'))
       || (github.event.action =='reopened' && contains(join(github.event.pull_request.labels.*.name, ','), 'run-on-dme'))
-      )
     runs-on: ubuntu-latest
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
-      # - name: Run Nala
-      #   uses: adobecom/dme-partners@stage # Change if doing dev work
-      #   env:
-      #     labels: ${{ join(github.event.pull_request.labels.*.name, ' ') }}
-      #     branch: ${{ github.event.pull_request.head.ref }}
-      #     repoName: ${{ github.repository }}
-      #     prUrl: ${{ github.event.pull_request.head.repo.html_url }}
-      #     prOrg: ${{ github.event.pull_request.head.repo.owner.login }}
-      #     prRepo: ${{ github.event.pull_request.head.repo.name }}
-      #     prBranch: ${{ github.event.pull_request.head.ref }}
-      #     prBaseBranch: ${{ github.event.pull_request.base.ref }}
-      #     IMS_EMAIL: ${{ secrets.IMS_EMAIL }}
-      #     IMS_PASS: ${{ secrets.IMS_PASS }}
-      #     HLX_API_KEY: ${{ secrets.HLX_API_KEY }}
+      - name: Run Nala
+        uses: adobecom/dme-partners@stage # Change if doing dev work
+        env:
+          labels: ${{ '@anonymous' }}
+          branch: ${{ github.event.pull_request.head.ref }}
+          repoName: ${{ github.repository }}
+          prUrl: ${{ github.event.pull_request.head.repo.html_url }}
+          prOrg: ${{ github.event.pull_request.head.repo.owner.login }}
+          prRepo: ${{ github.event.pull_request.head.repo.name }}
+          prBranch: ${{ github.event.pull_request.head.ref }}
+          prBaseBranch: ${{ github.event.pull_request.base.ref }}
+          IMS_EMAIL: ${{ secrets.IMS_EMAIL }}
+          IMS_PASS: ${{ secrets.IMS_PASS }}
+          HLX_API_KEY: ${{ secrets.HLX_API_KEY }}

--- a/.github/workflows/run-nala-on-dme.yml
+++ b/.github/workflows/run-nala-on-dme.yml
@@ -7,10 +7,9 @@ on:
 jobs:
   action:
     name: Running E2E & IT
-    if: or(
-      equal(github.event.label.name, 'run-on-dme'),
-      and(equal(github.event.action, 'synchronize'), contains(join(github.event.pull_request.labels.*.name, ','), 'run-on-dme')),
-      and(equal(github.event.action, 'reopened'), contains(join(github.event.pull_request.labels.*.name, ','), 'run-on-dme'))
+    if: github.event.label.name == 'run-on-dme'
+      || (github.event.action == 'synchronize' && contains(join(github.event.pull_request.labels.*.name, ','), 'run-on-dme'))
+      || (github.event.action =='reopened' && contains(join(github.event.pull_request.labels.*.name, ','), 'run-on-dme'))
       )
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Nala test are executed only once and only when:
- PR is created with `run-on-dme` label or the label was added later
- PR was updated and it has `run-on-dme` label
- PR was reopened and it has `run-on-dme` label

There is no more need to add `@anonymous` label to the PR to trigger nala tests. 