### PR TITLE
Fix: non authored card titles come with appendix

### DIFF
--- a/nala/blocks/announcements/announcements.spec.js
+++ b/nala/blocks/announcements/announcements.spec.js
@@ -101,6 +101,7 @@ export default {
         cardsWithoutCollectionTag: 0,
         noTitleSearch: 'Without card title',
         cardsWithoutTitle: 0,
+        defaultCardTitle: 'Adobe Partner Connection',
       },
     },
     {

--- a/nala/blocks/announcements/announcements.test.js
+++ b/nala/blocks/announcements/announcements.test.js
@@ -259,7 +259,7 @@ test.describe('Validate announcements block', () => {
       await expect(parseInt(resultWithoutCollectionTagCard.split(' ')[0], 10)).toBe(data.cardsWithoutCollectionTag);
       await announcementsPage.clearAllSelector.click();
       const firstCardTitle = await announcementsPage.firstCardTitle;
-      await expect(firstCardTitle).toBeEmpty();
+      await expect(firstCardTitle).toContainText(data.defaultCardTitle);
       await announcementsPage.searchField.fill(data.noTitleSearch);
       const resultWithoutTitleCard = await announcementsPage.resultNumber.textContent();
       await expect(parseInt(resultWithoutTitleCard.split(' ')[0], 10)).toBe(data.cardsWithoutTitle);


### PR DESCRIPTION
Before: [https://stage--dme-partners--adobecom.hlx.live/channelpartners/drafts/automation/regression/announcements?georouting=off](https://stage--dme-partners--adobecom.hlx.live/channelpartners/drafts/automation/regression/announcements?georouting=off)

After: [https://default-card-title-test-fix--dme-partners--adobecom.hlx.live/channelpartners/drafts/automation/regression/announcements?georouting=off](https://default-card-title-test-fix--dme-partners--adobecom.hlx.live/channelpartners/drafts/automation/regression/announcements?georouting=off)