### PR TITLE
New: added geo pop-up tests

### DIFF
--- a/nala/blocks/popups/popups.page.js
+++ b/nala/blocks/popups/popups.page.js
@@ -1,0 +1,17 @@
+export default class PopupsPage {
+  constructor(page) {
+    this.page = page;
+  }
+
+  getGeoPopUpElement(popUpText) {
+    return this.page.locator(`div.georouting-wrapper:has-text("${popUpText}")`);
+  }
+
+  getGeoLocaleButton(type) {
+    return this.page.locator(`a[daa-ll="${type}"]`);
+  }
+
+  async clickLocaleButton(type) {
+    await this.page.locator(`a[daa-ll="${type}"]`).click();
+  }
+}

--- a/nala/blocks/popups/popups.spec.js
+++ b/nala/blocks/popups/popups.spec.js
@@ -1,0 +1,112 @@
+export default {
+  FeatureName: 'DME Popups',
+  features: [
+    {
+      tcid: '1',
+      name: '@desc-regression-geo-pop-up-german-locale',
+      path: '/channelpartners/?akamaiLocale=de',
+      tags: '@dme-popups @geo-popups @regression @anonymous',
+      data: {
+        geoPopUpText: 'Diese Adobe-Site passt nicht zu Ihrem Standort',
+        buttonType: 'Switch:de-us|Geo_Routing_Modal',
+        switchLocaleUrl: '/de/channelpartners/?akamaiLocale=de',
+      },
+    },
+    {
+      tcid: '2',
+      name: '@desc-regression-geo-pop-up-spanish-locale',
+      path: '/channelpartners/?akamaiLocale=es',
+      tags: '@dme-popups @geo-popups @regression @anonymous',
+      data: {
+        geoPopUpText: 'Este sitio de Adobe no coincide con tu ubicación',
+        buttonType: 'Switch:es-us|Geo_Routing_Modal',
+        switchLocaleUrl: '/es/channelpartners/?akamaiLocale=es',
+      },
+    },
+    {
+      tcid: '3',
+      name: '@desc-regression-geo-pop-up-french-locale',
+      path: '/channelpartners/?akamaiLocale=fr',
+      tags: '@dme-popups @geo-popups @regression @anonymous',
+      data: {
+        geoPopUpText: 'Ce site Adobe ne correspond pas à votre zone géographique',
+        buttonType: 'Switch:fr-us|Geo_Routing_Modal',
+        switchLocaleUrl: '/fr/channelpartners/?akamaiLocale=fr',
+      },
+    },
+    {
+      tcid: '4',
+      name: '@desc-regression-geo-pop-up-italian-locale',
+      path: '/channelpartners/?akamaiLocale=it',
+      tags: '@dme-popups @geo-popups @regression @anonymous',
+      data: {
+        geoPopUpText: 'Questo sito Adobe non corrisponde alla tua posizione geografica',
+        buttonType: 'Switch:it-us|Geo_Routing_Modal',
+        switchLocaleUrl: '/it/channelpartners/?akamaiLocale=it',
+      },
+    },
+    {
+      tcid: '5',
+      name: '@desc-regression-geo-pop-up-japanese-locale',
+      path: '/channelpartners/?akamaiLocale=jp',
+      tags: '@dme-popups @geo-popups @regression @anonymous',
+      data: {
+        geoPopUpText: 'アドビwebサイトの地域設定がお客様の位置情報と一致しません',
+        buttonType: 'Switch:jp-us|Geo_Routing_Modal',
+        switchLocaleUrl: '/jp/channelpartners/?akamaiLocale=jp',
+      },
+    },
+    {
+      tcid: '6',
+      name: '@desc-regression-geo-pop-up-chinese-locale',
+      path: '/channelpartners/?akamaiLocale=cn',
+      tags: '@dme-popups @geo-popups @regression @anonymous',
+      data: {
+        geoPopUpText: '此 Adobe 网站与您的位置不匹配',
+        buttonType: 'Switch:cn-us|Geo_Routing_Modal',
+        switchLocaleUrl: '/cn/channelpartners/?akamaiLocale=cn',
+      },
+    },
+    {
+      tcid: '7',
+      name: '@desc-regression-geo-pop-up-brazilian-locale',
+      path: '/channelpartners/?akamaiLocale=br',
+      tags: '@dme-popups @geo-popups @regression @anonymous',
+      data: {
+        geoPopUpText: 'Este sitio de Adobe no coincide con tu ubicación',
+        buttonType: 'Switch:la-us|Geo_Routing_Modal',
+        switchLocaleUrl: '/la/channelpartners/?akamaiLocale=br',
+      },
+    },
+    {
+      tcid: '8',
+      name: '@desc-regression-accessing-german-public-page-switch-to-spanish-locale',
+      path: '/de/channelpartners/?akamaiLocale=es',
+      tags: '@dme-popups @geo-popups @regression @anonymous',
+      data: {
+        geoPopUpText: 'Este sitio de Adobe no coincide con tu ubicación',
+        switchLocaleButton: 'Switch:es-de|Geo_Routing_Modal',
+        stayLocaleButton: 'Stay:de-es|Geo_Routing_Modal',
+        switchLocaleUrl: '/es/channelpartners/?akamaiLocale=es',
+        stayLocaleUrl: '#',
+        clickButtonType: 'Switch:es-de|Geo_Routing_Modal',
+        expectedToSeeInURL: '/es/channelpartners/',
+      },
+    },
+    {
+      tcid: '9',
+      name: '@desc-regression-accessing-german-public-page-stay-on-german-locale',
+      path: '/de/channelpartners/?akamaiLocale=es',
+      tags: '@dme-popups @geo-popups @regression @anonymous',
+      data: {
+        geoPopUpText: 'Este sitio de Adobe no coincide con tu ubicación',
+        switchLocaleButton: 'Switch:es-de|Geo_Routing_Modal',
+        stayLocaleButton: 'Stay:de-es|Geo_Routing_Modal',
+        switchLocaleUrl: '/es/channelpartners/?akamaiLocale=es',
+        stayLocaleUrl: '#',
+        clickButtonType: 'Stay:de-es|Geo_Routing_Modal',
+        expectedToSeeInURL: '/de/channelpartners/',
+      },
+    },
+  ],
+};

--- a/nala/blocks/popups/popups.test.js
+++ b/nala/blocks/popups/popups.test.js
@@ -1,0 +1,77 @@
+import { test, expect } from '@playwright/test';
+import PopupsPage from './popups.page.js';
+import Popups from './popups.spec.js';
+
+let popupsPage;
+
+const { features } = Popups;
+const differentLocaleCases = features.slice(0, 7);
+const switchLocaleCases = features.slice(7, 9);
+
+test.describe('Validate popups', () => {
+  test.beforeEach(async ({ page, baseURL, browserName, context }) => {
+    popupsPage = new PopupsPage(page);
+    if (!baseURL.includes('partners.stage.adobe.com')) {
+      await context.setExtraHTTPHeaders({ authorization: `token ${process.env.HLX_API_KEY}` });
+    }
+    if (browserName === 'chromium' && !baseURL.includes('partners.stage.adobe.com')) {
+      await page.route('https://www.adobe.com/chimera-api/**', async (route, request) => {
+        const newUrl = request.url().replace(
+          'https://www.adobe.com/chimera-api',
+          'https://14257-chimera.adobeioruntime.net/api/v1/web/chimera-0.0.1',
+        );
+        route.continue({ url: newUrl });
+      });
+    }
+  });
+
+  differentLocaleCases.forEach((feature) => {
+    test(`${feature.name},${feature.tags}`, async ({ page, baseURL }) => {
+      const newBaseUrl = baseURL.includes('adobecom.hlx.live') ? 'https://partners.stage.adobe.com' : baseURL;
+      await test.step('Go to public page', async () => {
+        await page.goto(`${newBaseUrl}${feature.path}`);
+        await page.waitForLoadState();
+      });
+
+      await test.step('Verify geo pop-up appeared', async () => {
+        const geoPopUp = await popupsPage.getGeoPopUpElement(feature.data.geoPopUpText);
+        await expect(geoPopUp).toBeVisible();
+        const switchLocaleButton = await popupsPage.getGeoLocaleButton(feature.data.buttonType);
+        await expect(switchLocaleButton).toBeVisible();
+        const href = await switchLocaleButton.getAttribute('href');
+        await expect(href).toContain(feature.data.switchLocaleUrl);
+      });
+    });
+  });
+
+  switchLocaleCases.forEach((feature) => {
+    test(`${feature.name},${feature.tags}`, async ({ page, baseURL }) => {
+      const newBaseUrl = baseURL.includes('adobecom.hlx.live') ? 'https://partners.stage.adobe.com' : baseURL;
+      await test.step('Go to public page', async () => {
+        await page.goto(`${newBaseUrl}${feature.path}`);
+        await page.waitForLoadState();
+      });
+
+      await test.step('Verify geo pop-up appeared', async () => {
+        const geoPopUp = await popupsPage.getGeoPopUpElement(feature.data.geoPopUpText);
+        await expect(geoPopUp).toBeVisible();
+        const switchLocaleButton = await popupsPage.getGeoLocaleButton(feature.data.switchLocaleButton);
+        await expect(switchLocaleButton).toBeVisible();
+        const hrefSwitch = await switchLocaleButton.getAttribute('href');
+        await expect(hrefSwitch).toContain(feature.data.switchLocaleUrl);
+        const stayLocaleButton = await popupsPage.getGeoLocaleButton(feature.data.stayLocaleButton);
+        await expect(stayLocaleButton).toBeVisible();
+        const hrefStay = await stayLocaleButton.getAttribute('href');
+        await expect(hrefStay).toContain(feature.data.stayLocaleUrl);
+        await popupsPage.clickLocaleButton(feature.data.clickButtonType);
+        await page.waitForLoadState();
+      });
+
+      await test.step('Verify locale switch', async () => {
+        const pages = await page.context().pages();
+        await expect(pages[0].url())
+          .toContain(feature.data.expectedToSeeInURL);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Before: [https://stage--dme-partners--adobecom.hlx.live/channelpartners/?georouting=off](https://stage--dme-partners--adobecom.hlx.live/channelpartners/?georouting=off)

After: [https://MWPW-159124-geo-pop-up-tests--dme-partners--adobecom.hlx.live/channelpartners/?georouting=off](https://MWPW-159124-geo-pop-up-tests--dme-partners--adobecom.hlx.live/channelpartners/?georouting=off)