### PR TITLE
Fix: tests adjusted to run on circle ci

### DIFF
--- a/nala/blocks/popups/popups.spec.js
+++ b/nala/blocks/popups/popups.spec.js
@@ -4,8 +4,8 @@ export default {
     {
       tcid: '1',
       name: '@desc-regression-geo-pop-up-german-locale',
-      path: '/channelpartners/?akamaiLocale=de',
-      tags: '@dme-popups @geo-popups @regression',
+      path: '/channelpartners/?akamaiLocale=de&martech=off',
+      tags: '@dme-popups @geo-popups @regression @circleCi',
       data: {
         geoPopUpText: 'Diese Adobe-Site passt nicht zu Ihrem Standort',
         buttonType: 'Switch:de-us|Geo_Routing_Modal',
@@ -15,8 +15,8 @@ export default {
     {
       tcid: '2',
       name: '@desc-regression-geo-pop-up-spanish-locale',
-      path: '/channelpartners/?akamaiLocale=es',
-      tags: '@dme-popups @geo-popups @regression',
+      path: '/channelpartners/?akamaiLocale=es&martech=off',
+      tags: '@dme-popups @geo-popups @regression @circleCi',
       data: {
         geoPopUpText: 'Este sitio de Adobe no coincide con tu ubicación',
         buttonType: 'Switch:es-us|Geo_Routing_Modal',
@@ -26,8 +26,8 @@ export default {
     {
       tcid: '3',
       name: '@desc-regression-geo-pop-up-french-locale',
-      path: '/channelpartners/?akamaiLocale=fr',
-      tags: '@dme-popups @geo-popups @regression',
+      path: '/channelpartners/?akamaiLocale=fr&martech=off',
+      tags: '@dme-popups @geo-popups @regression @circleCi',
       data: {
         geoPopUpText: 'Ce site Adobe ne correspond pas à votre zone géographique',
         buttonType: 'Switch:fr-us|Geo_Routing_Modal',
@@ -37,8 +37,8 @@ export default {
     {
       tcid: '4',
       name: '@desc-regression-geo-pop-up-italian-locale',
-      path: '/channelpartners/?akamaiLocale=it',
-      tags: '@dme-popups @geo-popups @regression',
+      path: '/channelpartners/?akamaiLocale=it&martech=off',
+      tags: '@dme-popups @geo-popups @regression @circleCi',
       data: {
         geoPopUpText: 'Questo sito Adobe non corrisponde alla tua posizione geografica',
         buttonType: 'Switch:it-us|Geo_Routing_Modal',
@@ -48,8 +48,8 @@ export default {
     {
       tcid: '5',
       name: '@desc-regression-geo-pop-up-japanese-locale',
-      path: '/channelpartners/?akamaiLocale=jp',
-      tags: '@dme-popups @geo-popups @regression',
+      path: '/channelpartners/?akamaiLocale=jp&martech=off',
+      tags: '@dme-popups @geo-popups @regression @circleCi',
       data: {
         geoPopUpText: 'アドビwebサイトの地域設定がお客様の位置情報と一致しません',
         buttonType: 'Switch:jp-us|Geo_Routing_Modal',
@@ -59,8 +59,8 @@ export default {
     {
       tcid: '6',
       name: '@desc-regression-geo-pop-up-chinese-locale',
-      path: '/channelpartners/?akamaiLocale=cn',
-      tags: '@dme-popups @geo-popups @regression',
+      path: '/channelpartners/?akamaiLocale=cn&martech=off',
+      tags: '@dme-popups @geo-popups @regression @circleCi',
       data: {
         geoPopUpText: '此 Adobe 网站与您的位置不匹配',
         buttonType: 'Switch:cn-us|Geo_Routing_Modal',
@@ -70,8 +70,8 @@ export default {
     {
       tcid: '7',
       name: '@desc-regression-geo-pop-up-brazilian-locale',
-      path: '/channelpartners/?akamaiLocale=br',
-      tags: '@dme-popups @geo-popups @regression',
+      path: '/channelpartners/?akamaiLocale=br&martech=off',
+      tags: '@dme-popups @geo-popups @regression @circleCi',
       data: {
         geoPopUpText: 'Este sitio de Adobe no coincide con tu ubicación',
         buttonType: 'Switch:la-us|Geo_Routing_Modal',
@@ -81,8 +81,8 @@ export default {
     {
       tcid: '8',
       name: '@desc-regression-accessing-german-public-page-switch-to-spanish-locale',
-      path: '/de/channelpartners/?akamaiLocale=es',
-      tags: '@dme-popups @geo-popups @regression',
+      path: '/de/channelpartners/?akamaiLocale=es&martech=off',
+      tags: '@dme-popups @geo-popups @regression @circleCi',
       data: {
         geoPopUpText: 'Este sitio de Adobe no coincide con tu ubicación',
         switchLocaleButton: 'Switch:es-de|Geo_Routing_Modal',
@@ -96,8 +96,8 @@ export default {
     {
       tcid: '9',
       name: '@desc-regression-accessing-german-public-page-stay-on-german-locale',
-      path: '/de/channelpartners/?akamaiLocale=es',
-      tags: '@dme-popups @geo-popups @regression',
+      path: '/de/channelpartners/?akamaiLocale=es&martech=off',
+      tags: '@dme-popups @geo-popups @regression @circleCi',
       data: {
         geoPopUpText: 'Este sitio de Adobe no coincide con tu ubicación',
         switchLocaleButton: 'Switch:es-de|Geo_Routing_Modal',


### PR DESCRIPTION
Before: [https://stage--dme-partners--adobecom.hlx.live/channelpartners/?georouting=off](https://stage--dme-partners--adobecom.hlx.live/channelpartners/?georouting=off)

After: [https://geo-popup-tests-fix--dme-partners--adobecom.hlx.live/channelpartners/?georouting=off](https://geo-popup-tests-fix--dme-partners--adobecom.hlx.live/channelpartners/?georouting=off)

**Important note:** Geo pop-up tests could not be ran on the feature branches due to vpn. Since all the tests depend on partners.stage.adobe.com, tests will be ran on the circleCi instead.