### PR TITLE
AEP config

### DIFF
--- a/edsdme/scripts/scripts.js
+++ b/edsdme/scripts/scripts.js
@@ -49,6 +49,9 @@ const CONFIG = {
     pt: { ietf: 'pt-PT', tk: 'inq1xob.css' },
     la: { ietf: 'es', tk: 'oln4yqj.css' },
   },
+  local: { edgeConfigId: '72b074a6-76d2-43de-a210-124acc734f1c' },
+  stage: { edgeConfigId: '72b074a6-76d2-43de-a210-124acc734f1c' },
+  prod: { edgeConfigId: '913eac4d-900b-45e8-9ee7-306216765cd2' },
 };
 
 (function removeAccessToken() {


### PR DESCRIPTION
Added APC configs for AEP (Analytics)

Before:
https://partners.stage.adobe.com/channelpartners/

After:
https://mwpw-147197-aep--dme-partners--adobecom.hlx.live/channelpartners/

Check `window.marketingtech.adobe.alloy.edgeConfigId`