### PR TITLE
MWPW-154152-remove authorization header since it is not supporeted

### DIFF
--- a/edsdme/blocks/search/SearchCards.js
+++ b/edsdme/blocks/search/SearchCards.js
@@ -90,7 +90,6 @@ export default class Search extends PartnerCards {
 
     const headers = new Headers();
     headers.append('Content-Type', 'application/json');
-    headers.append('Authorization', 'Basic NDA3M2UwZTgtMTNlMC00ZjZjLWI5ZTMtZjBhZmQwYWM0ZDMzOjJKMnY1ODdnR3dtVXhoQjNRNlI2NDIydlJNUDYwRDZBYnJtSzRpRTJrMDBmdlI1VGMxRXNRbG9Vc2dBYTNNSUg=');
 
     let apiData;
     try {


### PR DESCRIPTION
before: https://stage--dme-partners--adobecom.hlx.page/channelpartners/home/search/

after: https://MWPW-154152-remove-authorization-header--dme-partners--adobecom.hlx.page/channelpartners/home/search/?georouting=off