### PR TITLE
MWPW-161395-send original value of filters (not translated ones) to s…

### DIFF
--- a/edsdme/blocks/search/SearchCards.js
+++ b/edsdme/blocks/search/SearchCards.js
@@ -208,7 +208,7 @@ export default class Search extends PartnerCards {
     const filters = Object.fromEntries(
       Object.entries(this.selectedFilters).map(([key, arr]) => [
         key,
-        arr.map((item) => item.value),
+        arr.map((item) => item.key),
       ]),
     );
     return { filters };


### PR DESCRIPTION
…earch api

before: https://stage--dme-partners--adobecom.hlx.page/channelpartners/home/search/

after: https://mwpw-161395-filter-values--dme-partners--adobecom.hlx.page/channelpartners/home/search/?georouting=off