### PR TITLE
Fix: selector for the change region pop-up changed

### DIFF
--- a/nala/blocks/region-selectors/region-selectors.page.js
+++ b/nala/blocks/region-selectors/region-selectors.page.js
@@ -1,7 +1,7 @@
 export default class RegionSelectorsPage {
   constructor(page) {
     this.page = page;
-    this.regionSelectorPopUp = page.locator('div.region-nav[data-block]');
+    this.regionSelectorPopUp = page.locator('div.region-nav');
     this.profileIconButton = page.locator('.feds-profile-button');
 
     this.oneTrustBanner = page.getByLabel('Cookie banner');


### PR DESCRIPTION
Selector for the change region pop-up has been updated.

Before: [https://stage--dme-partners--adobecom.hlx.live/channelpartners/?georouting=off](https://stage--dme-partners--adobecom.hlx.live/channelpartners/?georouting=off)

After: [https://region-selector-fix--dme-partners--adobecom.hlx.live/channelpartners/?georouting=off](https://region-selector-fix--dme-partners--adobecom.hlx.live/channelpartners/?georouting=off)