### PR TITLE
Fix: removed obsolete test for worldwide cards;

### DIFF
--- a/nala/blocks/announcements/announcements.spec.js
+++ b/nala/blocks/announcements/announcements.spec.js
@@ -310,22 +310,6 @@ export default {
     },
     {
       tcid: '19',
-      name: '@desc-regression-worldwide-cards-not-visible-for-logged-in-users',
-      path: '/channelpartners/drafts/automation/regression/announcements?georouting=off&martech=off',
-      tags: '@dme-announcements @regression @anonymous',
-      data: {
-        partnerData: {
-          partnerPortal: 'CPP',
-          partnerLevel: 'Distributor',
-          permissionRegion: 'North America',
-        },
-        announcementCardTitle: 'Worldwide',
-        numberOfMatchingTitleCardsNonLoggedIn: 6,
-        numberOfMatchingTitleCardsLoggedIn: 6,
-      },
-    },
-    {
-      tcid: '20',
       name: '@desc-regression-logged-in-platinum-user',
       path: '/channelpartners/drafts/automation/regression/announcements?georouting=off&martech=off',
       tags: '@dme-announcements @regression @anonymous',
@@ -336,12 +320,12 @@ export default {
           permissionRegion: 'Europe West',
         },
         platinumCardTitle: 'CPP Platinum Spain Announcement',
-        totalNumberOfCards: 4,
+        totalNumberOfCards: 11,
         numberOfMatchingTitleCards: 1,
       },
     },
     {
-      tcid: '21',
+      tcid: '20',
       name: '@desc-regression-logged-in-gold-user',
       path: '/channelpartners/drafts/automation/regression/announcements?georouting=off&martech=off',
       tags: '@dme-announcements @regression @anonymous',
@@ -359,7 +343,7 @@ export default {
       },
     },
     {
-      tcid: '22',
+      tcid: '21',
       name: '@desc-regression-logged-in-certified-user',
       path: '/channelpartners/drafts/automation/regression/announcements?georouting=off&martech=off',
       tags: '@dme-announcements @regression @anonymous',
@@ -377,7 +361,7 @@ export default {
       },
     },
     {
-      tcid: '23',
+      tcid: '22',
       name: '@desc-regression-logged-in-registered-user',
       path: '/channelpartners/drafts/automation/regression/announcements?georouting=off&martech=off',
       tags: '@dme-announcements @regression @anonymous',

--- a/nala/blocks/announcements/announcements.test.js
+++ b/nala/blocks/announcements/announcements.test.js
@@ -8,7 +8,7 @@ let singInPage;
 
 const { features } = Announcements;
 const regionCases = features.slice(6, 18);
-const partnerLevelCases = features.slice(20, 23);
+const partnerLevelCases = features.slice(19, 22);
 
 test.describe('Validate announcements block', () => {
   test.beforeEach(async ({ page, browserName, baseURL, context }) => {
@@ -299,37 +299,6 @@ test.describe('Validate announcements block', () => {
 
   test(`${features[18].name},${features[18].tags}`, async ({ page, context, baseURL }) => {
     const { data, path } = features[18];
-    await test.step('Go to Announcements page', async () => {
-      await page.goto(`${baseURL}${path}`);
-      await handleEvent(page);
-    });
-
-    await test.step(`Verify card titled ${data.announcementCardTitle} is present on page`, async () => {
-      await announcementsPage.searchField.fill(`${data.announcementCardTitle}`);
-      await announcementsPage.firstCardDate.waitFor({ state: 'visible', timeout: 15000 });
-      const result = await announcementsPage.resultNumber.textContent();
-      await expect(parseInt(result.split(' ')[0], 10)).toBe(data.numberOfMatchingTitleCardsNonLoggedIn);
-    });
-
-    await test.step('Set partner_data cookie', async () => {
-      await singInPage.addCookie(
-        data.partnerData,
-        `${baseURL}${path}`,
-        context,
-      );
-      await page.reload();
-      await handleEvent(page);
-    });
-
-    await test.step(`Verify card titled ${data.announcementCardTitle} is not present on page after login`, async () => {
-      await announcementsPage.searchField.fill(`${data.announcementCardTitle}`);
-      const result = await announcementsPage.resultNumber.textContent();
-      await expect(parseInt(result.split(' ')[0], 10)).toBe(data.numberOfMatchingTitleCardsLoggedIn);
-    });
-  });
-
-  test(`${features[19].name},${features[19].tags}`, async ({ page, context, baseURL }) => {
-    const { data, path } = features[19];
     await test.step('Go to Announcements page', async () => {
       await page.goto(`${baseURL}${path}`);
     });


### PR DESCRIPTION
Obsolete test for worldwide cards not being visible for logged-in users is removed. Logged-in scenarios total cards corrected accordingly.

Before: [https://stage--dme-partners--adobecom.hlx.live/channelpartners/?georouting=off](https://stage--dme-partners--adobecom.hlx.live/channelpartners/?georouting=off)

After: [https://announcement-tests-fix--dme-partners--adobecom.hlx.live/channelpartners/?georouting=off](https://announcement-tests-fix--dme-partners--adobecom.hlx.live/channelpartners/?georouting=off)