### PR TITLE
showing tags on assets

### DIFF
--- a/edsdme/blocks/announcements/announcements.js
+++ b/edsdme/blocks/announcements/announcements.js
@@ -1,17 +1,10 @@
 import { getLibs, getCaasUrl } from '../../scripts/utils.js';
-import { replaceText, getConfig, populateLocalizedTextFromListItems } from '../utils/utils.js';
+import { getConfig, populateLocalizedTextFromListItems, localizationPromises } from '../utils/utils.js';
 import Announcements from './AnnouncementsCards.js';
 
 function declareAnnouncements() {
   if (customElements.get('announcements-cards')) return;
   customElements.define('announcements-cards', Announcements);
-}
-
-async function localizationPromises(localizedText, config) {
-  return Promise.all(Object.keys(localizedText).map(async (key) => {
-    const value = await replaceText(key, config);
-    if (value.length) localizedText[key] = value;
-  }));
 }
 
 export default async function init(el) {

--- a/edsdme/blocks/logos/logos.js
+++ b/edsdme/blocks/logos/logos.js
@@ -1,17 +1,10 @@
 import { getLibs } from '../../scripts/utils.js';
-import { replaceText, getConfig, populateLocalizedTextFromListItems } from '../utils/utils.js';
+import { getConfig, populateLocalizedTextFromListItems, localizationPromises } from '../utils/utils.js';
 import Logos from './LogosCards.js';
 
 function declareLogos() {
   if (customElements.get('logos-cards')) return;
   customElements.define('logos-cards', Logos);
-}
-
-async function localizationPromises(localizedText, config) {
-  return Promise.all(Object.keys(localizedText).map(async (key) => {
-    const value = await replaceText(key, config);
-    if (value.length) localizedText[key] = value;
-  }));
 }
 
 export default async function init(el) {

--- a/edsdme/blocks/search/search.js
+++ b/edsdme/blocks/search/search.js
@@ -1,17 +1,10 @@
 import { getLibs } from '../../scripts/utils.js';
-import { replaceText, getConfig, populateLocalizedTextFromListItems } from '../utils/utils.js';
+import { getConfig, populateLocalizedTextFromListItems, localizationPromises } from '../utils/utils.js';
 import Search from './SearchCards.js';
 
 function declareSearch() {
   if (customElements.get('search-cards')) return;
   customElements.define('search-cards', Search);
-}
-
-async function localizationPromises(localizedText, config) {
-  return Promise.all(Object.keys(localizedText).map(async (key) => {
-    const value = await replaceText(key, config);
-    if (value.length) localizedText[key] = value;
-  }));
 }
 
 export default async function init(el) {

--- a/edsdme/blocks/utils/utils.js
+++ b/edsdme/blocks/utils/utils.js
@@ -18,6 +18,14 @@ export function populateLocalizedTextFromListItems(el, localizedText) {
     localizedText[`{{${liContent}}}`] = liContent;
   });
 }
+export async function localizationPromises(localizedText, config) {
+  return Promise.all(Object.keys(localizedText).map(async (key) => {
+    const value = await replaceText(key, config);
+    if (value.length) {
+      localizedText[key] = value;
+    }
+  }));
+}
 
 export function generateRequestForSearchAPI(pageOptions, body) {
   const { env, locales } = getConfig();

--- a/edsdme/components/SearchCard.js
+++ b/edsdme/components/SearchCard.js
@@ -20,7 +20,10 @@ class SearchCard extends LitElement {
     return html`${repeat(
       tags,
       (tag) => tag.key,
-      (tag) => html`<span class="card-tag">${this.localizedText[`{{${Object.values(tag)[0]}}}`]}</span>`,
+      (tag) => {
+        const key = Object.values(tag)[0];
+        return html`<span class="card-tag">${this.localizedText[`{{${key}}}`] || key.replaceAll('-', ' ')}</span>`;
+      },
     )}`;
   }
 


### PR DESCRIPTION
tags are shown how they came from Content Library if they are not declared in placeholders file
moved localizationPromises to utils, since its used by multiple blocks

testing url: https://mwpw-162007-tags-list-on-assets--dme-partners--adobecom.hlx.page/channelpartners/drafts/dragana/search