### PR TITLE
New: included nala test for japan region

### DIFF
--- a/nala/blocks/announcements-preview/announcements-preview.spec.js
+++ b/nala/blocks/announcements-preview/announcements-preview.spec.js
@@ -131,19 +131,18 @@ export default {
         rootPath: '/channelpartners/',
       },
     },
-    // This will also be included after MWPW-161391 resolves.
-    // {
-    //   tcid: '11',
-    //   name: '@desc-regression-announcements-preview-japan-region',
-    //   path: '/channelpartners/?georouting=off&martech=off',
-    //   tags: '@dme-announcements-preview @regression @circleCi',
-    //   data: {
-    //     partnerLevel: 'cpp-distributor-japan:',
-    //     signInButton: 'Sign In',
-    //     expectedProtectedHomeURL: 'https://partners.stage.adobe.com/channelpartners/home/',
-    //     selectedSortNewest: 'Date: newest',
-    //     rootPath: '/channelpartners/',
-    //   },
-    // },
+    {
+      tcid: '11',
+      name: '@desc-regression-announcements-preview-japan-region',
+      path: '/channelpartners/?georouting=off&martech=off',
+      tags: '@dme-announcements-preview @regression @circleCi',
+      data: {
+        partnerLevel: 'cpp-distributor-japan:',
+        signInButton: 'Sign In',
+        expectedProtectedHomeURL: 'https://partners.stage.adobe.com/channelpartners/home/',
+        selectedSortNewest: 'Date: newest',
+        rootPath: '/channelpartners/',
+      },
+    },
   ],
 };

--- a/nala/blocks/announcements-preview/announcements-preview.test.js
+++ b/nala/blocks/announcements-preview/announcements-preview.test.js
@@ -7,7 +7,7 @@ let announcementsPreviewPage;
 let signInPage;
 
 const { features } = AnnouncementsPreview;
-const regionBasedPreviews = features.slice(0, 10);
+const regionBasedPreviews = features.slice(0, 11);
 
 test.describe('Validate announcements preview block', () => {
   test.beforeEach(async ({ page, baseURL, browserName, context }) => {


### PR DESCRIPTION
As this ticket about worldwide announcements resolved [MWPW-161564](https://jira.corp.adobe.com/browse/MWPW-161564), the following bug [MWPW-161391](https://jira.corp.adobe.com/browse/MWPW-161391) can no longer be reproduced and we can safely include our nala test which covers japan region.


Before: [https://stage--dme-partners--adobecom.hlx.live/channelpartners/?georouting=off](https://stage--dme-partners--adobecom.hlx.live/channelpartners/?georouting=off)

After: [https://announcement-preview-tests-extended--dme-partners--adobecom.hlx.live/channelpartners/?georouting=off](https://announcement-preview-tests-extended--dme-partners--adobecom.hlx.live/channelpartners/?georouting=off)