### PR TITLE
MWPW-161641: Fixed logout from protected pages

### DIFF
--- a/edsdme/scripts/utils.js
+++ b/edsdme/scripts/utils.js
@@ -245,8 +245,10 @@ export async function getRenewBanner(getConfig, loadBlock) {
 }
 
 export function updateIMSConfig() {
+  const isSignedIn = partnerIsSignedIn();
   const imsReady = setInterval(() => {
     if (!window.adobeIMS) return;
+    if (isSignedIn && !window.adobeIMS.isSignedInUser()) return;
     clearInterval(imsReady);
     let target;
     const partnerLogin = !window.adobeIMS.isSignedInUser();

--- a/test/scripts/utils.jest.js
+++ b/test/scripts/utils.jest.js
@@ -383,12 +383,29 @@ describe('Test utils.js', () => {
     document.body.appendChild(main);
     expect(await getRenewBanner(getConfig, jest.fn())).toEqual(null);
   });
+  it('Update ims config if user is signed in', () => {
+    jest.useFakeTimers();
+    window.adobeIMS = {
+      isSignedInUser: () => true,
+      adobeIdData: {},
+    };
+    // document.cookie = `partner_data=${JSON.stringify(cookieObject)}`;
+    const metaTag = document.createElement('meta');
+    metaTag.name = 'adobe-target-after-logout';
+    metaTag.content = '/channelpartners/home';
+    document.head.appendChild(metaTag);
+    updateIMSConfig();
+    jest.advanceTimersByTime(1000);
+    const redirectUrl = new URL(window.adobeIMS.adobeIdData.redirect_uri);
+    expect(redirectUrl.pathname).toEqual(metaTag.content);
+  });
   it('Update ims config if user is not signed in', () => {
     jest.useFakeTimers();
     window.adobeIMS = {
       isSignedInUser: () => false,
       adobeIdData: {},
     };
+    document.cookie = 'partner_data=';
     const metaTag = document.createElement('meta');
     metaTag.name = 'adobe-target-after-login';
     metaTag.content = '/channelpartners/home';
@@ -398,21 +415,6 @@ describe('Test utils.js', () => {
     const redirectUrl = new URL(window.adobeIMS.adobeIdData.redirect_uri);
     expect(redirectUrl.pathname).toEqual(metaTag.content);
     expect(redirectUrl.searchParams.has('partnerLogin')).toEqual(true);
-  });
-  it('Update ims config if user is signed in', () => {
-    jest.useFakeTimers();
-    window.adobeIMS = {
-      isSignedInUser: () => true,
-      adobeIdData: {},
-    };
-    const metaTag = document.createElement('meta');
-    metaTag.name = 'adobe-target-after-logout';
-    metaTag.content = '/channelpartners/home';
-    document.head.appendChild(metaTag);
-    updateIMSConfig();
-    jest.advanceTimersByTime(1000);
-    const redirectUrl = new URL(window.adobeIMS.adobeIdData.redirect_uri);
-    expect(redirectUrl.pathname).toEqual(metaTag.content);
   });
   it('Get locale', () => {
     const locales = {


### PR DESCRIPTION
- `IMS` behaves little different when we do the redirect ourselves (via edgeworker) instead of user going through `IMS` redirect using `Sign In` button in gnav. Because of this `window.adobeIMS.isSignedInUser()` functions returns `false` even though user is signed in and it needs some time to get the correct information. That is why I extended `setInterval` to continue running if user has `partner_data` cookie (`IMS` login was successful) 

Resolves: [MWPW-161641](https://jira.corp.adobe.com/browse/MWPW-161641)

Before: https://stage--dme-partners--adobecom.hlx.live/channelpartners/
After: https://mwpw-161641-logout-protected--dme-partners--adobecom.hlx.live/channelpartners/