### PR TITLE
MWPW-163046: Prevent redirect when metadata equals //

### DIFF
--- a/edsdme/scripts/utils.js
+++ b/edsdme/scripts/utils.js
@@ -159,7 +159,7 @@ export function getMetadata(name) {
 export function redirectLoggedinPartner() {
   if (!isMember()) return;
   const target = getMetadataContent('adobe-target-after-login');
-  if (!target) return;
+  if (!target || target === '//') return;
   document.body.style.display = 'none';
   window.location.assign(target);
 }
@@ -259,7 +259,7 @@ export function updateIMSConfig() {
     const targetUrl = new URL(window.location.href);
     // eslint-disable-next-line chai-friendly/no-unused-expressions
     partnerLogin && targetUrl.searchParams.set(PARTNER_LOGIN_QUERY, true);
-    if (target) {
+    if (target && target !== '//') {
       targetUrl.pathname = target;
     }
     window.adobeIMS.adobeIdData.redirect_uri = targetUrl.toString();

--- a/edsdme/scripts/utils.js
+++ b/edsdme/scripts/utils.js
@@ -159,7 +159,7 @@ export function getMetadata(name) {
 export function redirectLoggedinPartner() {
   if (!isMember()) return;
   const target = getMetadataContent('adobe-target-after-login');
-  if (!target || target === '//') return;
+  if (!target || target === 'NONE') return;
   document.body.style.display = 'none';
   window.location.assign(target);
 }
@@ -259,7 +259,7 @@ export function updateIMSConfig() {
     const targetUrl = new URL(window.location.href);
     // eslint-disable-next-line chai-friendly/no-unused-expressions
     partnerLogin && targetUrl.searchParams.set(PARTNER_LOGIN_QUERY, true);
-    if (target && target !== '//') {
+    if (target && target !== 'NONE') {
       targetUrl.pathname = target;
     }
     window.adobeIMS.adobeIdData.redirect_uri = targetUrl.toString();


### PR DESCRIPTION
- redirect loggedin user to `adobe-target-after-login` url 
- if `adobe-target-after-login` value is `//` don't redirect
- don't update IMS redirect url if `adobe-target-after-login` value equals '//'

Resolves: [MWPW-163046](https://jira.corp.adobe.com/browse/MWPW-163046)

Before: https://stage--dme-partners--adobecom.hlx.live/channelpartners/
After: https://mwpw-163046-redirect-login-logout--dme-partners--adobecom.hlx.live/channelpartners/