### PR TITLE
MWPW-163532 - environment-specific partner finder gnav links

### DIFF
--- a/edsdme/blocks/partners-navigation/partners-navigation.js
+++ b/edsdme/blocks/partners-navigation/partners-navigation.js
@@ -33,6 +33,8 @@ import {
   darkIcons,
 } from './utilities/utilities.js';
 
+import { applyGnavLinkRewriting } from '../../scripts/links.js';
+
 // MWPW-157751
 import { getLibs } from '../../scripts/utils.js'; // MWPW-157751
 
@@ -1038,6 +1040,7 @@ export default async function init(block) {
     if (!content) return null;
     block.classList.add('global-navigation'); // MWPW-157751
     content = applyGnavPersonalization(content); // MWPW-157751
+    content = applyGnavLinkRewriting(content);
     const gnav = new Gnav({
       content,
       block,

--- a/edsdme/scripts/links.js
+++ b/edsdme/scripts/links.js
@@ -1,0 +1,52 @@
+import { getConfig } from '../blocks/utils/utils.js';
+
+/**
+ * Domain mappings where the key is the production domain,
+ * and the value is the corresponding stage domain.
+ */
+const domainMappings = {
+  'adobe.force.com': 'adobe--sfstage.sandbox.my.site.com',
+  'io-partners-dx.adobe.com': 'io-partners-dx.stage.adobe.com',
+  // add mappings here as necessary
+};
+
+/**
+ * Rewrite a link href domain based on production to stage domain mappings.
+ * @param {string} href - The link href to rewrite.
+ * @returns {string} - The rewritten link href, or the original if the environment is prod,
+ * there was a problem processing, or there is no domain mapping defined for it.
+ */
+export function rewriteLinkHref(href) {
+  const { env } = getConfig();
+
+  if (env.name === 'prod') return href;
+
+  let url;
+
+  try {
+    url = new URL(href);
+  } catch {
+    return href;
+  }
+
+  if (domainMappings[url.hostname]) {
+    url.hostname = domainMappings[url.hostname];
+    return url.toString();
+  }
+
+  return href;
+}
+
+/**
+ * Applies link rewriting to the global navigation,
+ * based on production to stage domain mappings.
+ * @param {HTMLElement} gnav - The global navigation.
+ */
+export function applyGnavLinkRewriting(gnav) {
+  const links = gnav.querySelectorAll('a[href]');
+  links.forEach((link) => {
+    link.href = rewriteLinkHref(link.href);
+  });
+
+  return gnav;
+}

--- a/edsdme/scripts/personalization.js
+++ b/edsdme/scripts/personalization.js
@@ -34,11 +34,6 @@ const PERSONALIZATION_CONDITIONS = {
   'partner-level': (level) => PARTNER_LEVEL === level,
 };
 
-const SALES_FORCE_DOMAINS = {
-  stage: 'adobe--sfstage.sandbox.my.site.com',
-  prod: 'adobe.force.com',
-};
-
 function personalizePlaceholders(placeholders, context = document) {
   Object.entries(placeholders).forEach(([key, value]) => {
     const placeholderValue = COOKIE_OBJECT[key];
@@ -231,26 +226,9 @@ function personalizeProfile(gnav) {
   processRenew(profile);
 }
 
-function rewriteSalesForceLinks(gnav) {
-  const { env } = getConfig();
-
-  if (env.name !== 'prod') {
-    const links = gnav.querySelectorAll('a[href]');
-    links.forEach((link) => {
-      const href = link.getAttribute('href');
-
-      if (href.includes(SALES_FORCE_DOMAINS.prod)) {
-        const newHref = href.replace(SALES_FORCE_DOMAINS.prod, SALES_FORCE_DOMAINS.stage);
-        link.setAttribute('href', newHref);
-      }
-    });
-  }
-}
-
 export function applyGnavPersonalization(gnav) {
   if (!isMember()) return gnav;
   const importedGnav = document.importNode(gnav, true);
-  rewriteSalesForceLinks(importedGnav);
   personalizeMainNav(importedGnav);
   personalizeProfile(importedGnav);
   return importedGnav;

--- a/test/scripts/links.jest.js
+++ b/test/scripts/links.jest.js
@@ -1,0 +1,81 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { applyGnavLinkRewriting, rewriteLinkHref } from '../../edsdme/scripts/links.js';
+import { getConfig } from '../../edsdme/blocks/utils/utils.js';
+
+jest.mock('../../edsdme/blocks/utils/utils.js', () => ({ getConfig: jest.fn() }));
+
+describe('Test links.js', () => {
+  beforeEach(() => {
+    getConfig.mockReturnValue({ env: { name: 'stage' } });
+  });
+
+  describe('rewriteLinkHref', () => {
+    test('should return link href unchanged in production environment', () => {
+      getConfig.mockReturnValue({ env: { name: 'prod' } });
+
+      const href = 'https://adobe.force.com/path';
+      const result = rewriteLinkHref(href);
+
+      expect(result).toBe(href);
+    });
+
+    test('should rewrite sales for link hrefs', () => {
+      const href = 'https://adobe.force.com/path';
+      const result = rewriteLinkHref(href);
+
+      expect(result).toBe('https://adobe--sfstage.sandbox.my.site.com/path');
+    });
+
+    test('should rewrite runtime link hrefs', () => {
+      const href = 'https://io-partners-dx.adobe.com/path';
+      const result = rewriteLinkHref(href);
+
+      expect(result).toBe('https://io-partners-dx.stage.adobe.com/path');
+    });
+
+    test('should return unchanged link hrefs if invalid', () => {
+      const href = 'invalid-url';
+      const result = rewriteLinkHref(href);
+
+      expect(result).toBe(href);
+    });
+
+    test('should return unchanged link hrefs if domain is not mapped', () => {
+      const href = 'https://unmapped-domain.com/path';
+      const result = rewriteLinkHref(href);
+
+      expect(result).toBe(href);
+    });
+  });
+
+  describe('applyGnavLinkRewriting', () => {
+    const gnav = document.createElement('div');
+    const gnavHTML = `
+        <a href="https://adobe.force.com/path"></a>
+        <a href="https://io-partners-dx.adobe.com/path"></a>
+        <a href="https://unmapped-domain.com/path"></a>
+      `;
+    gnav.innerHTML = gnavHTML;
+
+    test('should not rewrite links in the production environment', () => {
+      getConfig.mockReturnValue({ env: { name: 'prod' } });
+
+      const result = applyGnavLinkRewriting(gnav);
+
+      expect(result.innerHTML).toBe(gnavHTML);
+    });
+
+    test('should rewrite links in the stage environment', () => {
+      const result = applyGnavLinkRewriting(gnav);
+
+      expect(result.innerHTML).toBe(`
+        <a href="https://adobe--sfstage.sandbox.my.site.com/path"></a>
+        <a href="https://io-partners-dx.stage.adobe.com/path"></a>
+        <a href="https://unmapped-domain.com/path"></a>
+      `);
+    });
+  });
+});


### PR DESCRIPTION
Resolves: [MWPW-163532](https://jira.corp.adobe.com/browse/MWPW-163532)

- adds links script for rewriting single link hrefs based on prod stage mappings
- rewrites all links in the gnav
- removes sales force domain rewriting from personalization
- adds unit tests

Before: [https://stage--dme-partners--adobecom.hlx.live/channelpartners/home/](https://stage--dme-partners--adobecom.hlx.live/channelpartners/home/)
After: https://mwpw-163532-env-specific-links--dme-partners--adobecom.hlx.live/channelpartners/home/