### PR TITLE
New: added error pages nala tests

### DIFF
--- a/nala/blocks/signin/signin.spec.js
+++ b/nala/blocks/signin/signin.spec.js
@@ -171,5 +171,38 @@ export default {
         signInButtonText: 'Sign In', // This will require a change as soon as LA NA based is sorted out
       },
     },
+    {
+      tcid: '15',
+      name: '@login-accessing-public-home-page-access-denied-error',
+      path: 'https://partners.stage.adobe.com/channelpartners/drafts/automation/regression/public-page?georouting=off&martech=off',
+      tags: '@dme-signin @regression @login @circleCi',
+      data: {
+        partnerLevel: 'cpp-denied:',
+        expectedToSeeInURL: '/channelpartners/error/account-denied',
+        signInButtonInternationalText: 'Sign In',
+      },
+    },
+    {
+      tcid: '16',
+      name: '@login-accessing-public-home-page-account-abandoned-error',
+      path: 'https://partners.stage.adobe.com/channelpartners/drafts/automation/regression/public-page?georouting=off&martech=off',
+      tags: '@dme-signin @regression @login @circleCi',
+      data: {
+        partnerLevel: 'cpp-abandoned:',
+        expectedToSeeInURL: '/channelpartners/error/login-error',
+        signInButtonInternationalText: 'Sign In',
+      },
+    },
+    {
+      tcid: '17',
+      name: '@login-accessing-public-home-page-account-expired-error',
+      path: 'https://partners.stage.adobe.com/channelpartners/drafts/automation/regression/public-page?georouting=off&martech=off',
+      tags: '@dme-signin @regression @login @circleCi',
+      data: {
+        partnerLevel: 'cpp-expired:',
+        expectedToSeeInURL: '/channelpartners/error/account-expired',
+        signInButtonInternationalText: 'Sign In',
+      },
+    },
   ],
 };

--- a/nala/blocks/signin/signin.test.js
+++ b/nala/blocks/signin/signin.test.js
@@ -9,6 +9,7 @@ const redirectionFeatures = features.slice(1, 3);
 const nonMemberRedirects = features.slice(3, 5);
 const nonMemberLoggedInToAdobe = features.slice(5, 7);
 const resellerMembersLogin = features.slice(9, 13);
+const errorPages = features.slice(14, 17);
 
 test.describe('MAPC sign in flow', () => {
   test.beforeEach(async ({ page, browserName, baseURL, context }) => {
@@ -270,6 +271,27 @@ test.describe('MAPC sign in flow', () => {
       const joinNowButton = await signInPage.joinNowButton;
       await expect(joinNowButton).toBeVisible();
       await expect(signInButton).toBeVisible();
+    });
+  });
+
+  errorPages.forEach((feature) => {
+    test(`${feature.name},${feature.tags}`, async ({ page }) => {
+      await test.step('Go to the home page', async () => {
+        await page.goto(`${feature.path}`);
+        await page.waitForLoadState('domcontentloaded');
+        const signInButtonInt = await signInPage.getSignInButton(`${feature.data.signInButtonInternationalText}`);
+        await signInButtonInt.click();
+      });
+
+      await test.step('Sign in', async () => {
+        await signInPage.signIn(page, `${feature.data.partnerLevel}`);
+      });
+
+      await test.step('Verify redirection to the corresponding error page', async () => {
+        await signInPage.profileIconButton.waitFor({ state: 'visible', timeout: 20000 });
+        const pages = await page.context().pages();
+        await expect(pages[0].url()).toContain(`${feature.data.expectedToSeeInURL}`);
+      });
     });
   });
 });


### PR DESCRIPTION
Covers error page test cases (IDs: 17, 18, 19) defined in [Sign In Tests](https://wiki.corp.adobe.com/display/WEBT/MAPC+Sign+in+testing)

Before: [https://stage--dme-partners--adobecom.hlx.live/channelpartners/?georouting=off](https://stage--dme-partners--adobecom.hlx.live/channelpartners/?georouting=off)

After: [https://MWPW-163152-error-pages-tests--dme-partners--adobecom.hlx.live/channelpartners/?georouting=off](https://MWPW-163152-error-pages-tests--dme-partners--adobecom.hlx.live/channelpartners/?georouting=off)