### PR TITLE
Revert "use adobe.com instead of milo.com for milo libs since it contains lat…"

### DIFF
--- a/edsdme/scripts/utils.js
+++ b/edsdme/scripts/utils.js
@@ -31,7 +31,7 @@ export const [setLibs, getLibs] = (() => {
       libs = (() => {
         const { hostname, search, origin } = location || window.location;
         if (origin.endsWith('adobe.com')) {
-          return origin.replace('partners.', '') + prodLibs;
+          return origin.replace('partners', 'milo') + prodLibs;
         }
         const partnerBranch = hostname.startsWith('main') ? 'main' : 'stage';
         const branch = new URLSearchParams(search).get('milolibs') || partnerBranch;

--- a/test/scripts/utils.jest.js
+++ b/test/scripts/utils.jest.js
@@ -52,7 +52,7 @@ describe('Test utils.js', () => {
   it('Milo libs', () => {
     window.location.hostname = 'partners.stage.adobe.com';
     const libs = setLibs('/libs');
-    expect(libs).toEqual('https://stage.adobe.com/libs');
+    expect(libs).toEqual('https://milo.stage.adobe.com/libs');
   });
   describe('Test update footer and gnav', () => {
     beforeEach(() => {

--- a/test/scripts/utils.test.js
+++ b/test/scripts/utils.test.js
@@ -14,15 +14,15 @@ describe('Libs', () => {
     const libs = setLibs('/libs', location);
     expect(libs).to.equal('https://main--milo--adobecom.hlx.live/libs');
   });
-  it('Returns prod adobe for prod', () => {
+  it('Returns prod milo for prod', () => {
     const location = { origin: 'https://partners.adobe.com' };
     const libs = setLibs('/libs', location);
-    expect(libs).to.equal('https://adobe.com/libs');
+    expect(libs).to.equal('https://milo.adobe.com/libs');
   });
   it('Returns stage milo for stage', () => {
     const location = { origin: 'https://partners.stage.adobe.com' };
     const libs = setLibs('/libs', location);
-    expect(libs).to.equal('https://stage.adobe.com/libs');
+    expect(libs).to.equal('https://milo.stage.adobe.com/libs');
   });
 
   it('Does not support milolibs query param on prod', () => {
@@ -31,7 +31,7 @@ describe('Libs', () => {
       search: '?milolibs=foo',
     };
     const libs = setLibs('/libs', location);
-    expect(libs).to.equal('https://adobe.com/libs');
+    expect(libs).to.equal('https://milo.adobe.com/libs');
   });
 
   it('Supports milolibs query param', () => {


### PR DESCRIPTION
Reverts adobecom/dme-partners#164