### PR TITLE
MWPW-164313 - Pricelists are downloaded as .txt files instead of .csv

### DIFF
--- a/edsdme/blocks/pricelist/PricelistBlock.js
+++ b/edsdme/blocks/pricelist/PricelistBlock.js
@@ -17,6 +17,18 @@ export const priceListKeyWords = {
     DEFAULT: 'default',
   },
 };
+
+const extractFilename = (url) => {
+  const filenameWithExtension = url.substring(url.lastIndexOf('/') + 1);
+  const filenameWithoutExtension = filenameWithExtension.replace('.URL', '');
+
+  if (filenameWithoutExtension.endsWith('csv')) {
+    return `${filenameWithoutExtension.slice(0, -3)}.csv`;
+  }
+
+  return `${filenameWithoutExtension}.csv`;
+};
+
 export default class Pricelist extends PartnerCards {
   static styles = [
     PartnerCards.styles,
@@ -141,7 +153,7 @@ export default class Pricelist extends PartnerCards {
                     <sp-action-button
                             size="m"
                             href="${setDownloadParam(rowData.contentArea?.url)}"
-                            download="${rowData.contentArea?.title}"
+                            download="${extractFilename(rowData.contentArea?.url)}"
                             aria-label="${this.blockData.localizedText['{{download}}']}">
                         <sp-icon-download slot="icon"></sp-icon-download>
                         ${this.blockData.localizedText['{{download}}']}

--- a/edsdme/blocks/pricelist/PricelistBlock.js
+++ b/edsdme/blocks/pricelist/PricelistBlock.js
@@ -18,17 +18,6 @@ export const priceListKeyWords = {
   },
 };
 
-const extractFilename = (url) => {
-  const filenameWithExtension = url.substring(url.lastIndexOf('/') + 1);
-  const filenameWithoutExtension = filenameWithExtension.replace('.URL', '');
-
-  if (filenameWithoutExtension.endsWith('csv')) {
-    return `${filenameWithoutExtension.slice(0, -3)}.csv`;
-  }
-
-  return `${filenameWithoutExtension}.csv`;
-};
-
 export default class Pricelist extends PartnerCards {
   static styles = [
     PartnerCards.styles,
@@ -153,7 +142,7 @@ export default class Pricelist extends PartnerCards {
                     <sp-action-button
                             size="m"
                             href="${setDownloadParam(rowData.contentArea?.url)}"
-                            download="${extractFilename(rowData.contentArea?.url)}"
+                            download="${rowData.contentArea?.filename}"
                             aria-label="${this.blockData.localizedText['{{download}}']}">
                         <sp-icon-download slot="icon"></sp-icon-download>
                         ${this.blockData.localizedText['{{download}}']}


### PR DESCRIPTION
https://jira.corp.adobe.com/browse/MWPW-164313

- reads the pricelist filename property for setting up the download attribute

depends on https://git.corp.adobe.com/wcms/dx-partners-runtime/pull/128

https://mwpw-164313-pricelist-download-csv--dme-partners--adobecom.hlx.live/latam/channelpartners/drafts/automation/regression/pricelist