### PR TITLE
Fixing Announcments display

### DIFF
--- a/edsdme/blocks/search-full/SearchCardsStyles.js
+++ b/edsdme/blocks/search-full/SearchCardsStyles.js
@@ -30,6 +30,10 @@ export const searchCardsStyles = css`
     border: 1px solid #BCBCBC;
     border-radius: 12px;
   }
+
+  .partner-cards {
+    grid-template-columns: 269px auto;
+  }
   
   .search-box-wrapper .partner-cards-title {
     margin-bottom: 20px;
@@ -37,6 +41,8 @@ export const searchCardsStyles = css`
   
   .partner-cards-sidebar {
     padding-left: 0;
+    width: 269px;
+    max-width: 269px;
   }
   
   .partner-cards-sidebar .sidebar-header {

--- a/edsdme/components/PartnerCardsStyles.js
+++ b/edsdme/components/PartnerCardsStyles.js
@@ -24,7 +24,7 @@ export const partnerCardsStyles = css`
     width: 100%;
     margin: 0 auto;
     display: grid;
-    grid-template-columns: 269px auto;
+    grid-template-columns: 204px auto;
     gap: 32px;
   }
   
@@ -40,8 +40,8 @@ export const partnerCardsStyles = css`
   .partner-cards-sidebar {
     display: flex;
     flex-direction: column;
-    width: 269px;
-    max-width: 269px;
+    width: 204px;
+    max-width: 204px;
     margin-right: 32px;
     padding: 8px 16px 16px;
     border-radius: 4px;


### PR DESCRIPTION
Ticket: https://jira.corp.adobe.com/browse/MWPW-165153

There was ticket for `asset language` https://jira.corp.adobe.com/browse/MWPW-162444 and it had design for sidebar filter to be wider. This ticket was related to Search component

These changes include:

- reverting width of filters on Announcements (and other) component as it was before 204px
- setting width on sidebar filter only for Search component to 269px as it was in design in the ticket

Testing urls:

- https://mwpw-165153-cards-displayed--dme-partners--adobecom.hlx.page/channelpartners/home/search/
- https://mwpw-165153-cards-displayed--dme-partners--adobecom.hlx.page/channelpartners/home/announcements/