### PR TITLE
fix-for-banners

### DIFF
--- a/nala/blocks/banners/banners.page.js
+++ b/nala/blocks/banners/banners.page.js
@@ -1,12 +1,18 @@
 export default class BannersPage {
   constructor(page) {
     this.page = page;
-    this.renewBanner = page.locator('div.notification.ribbon');
+    this.renewBanner = page.locator('div.aside.notification.dark.extra-small.con-block.no-media');
+    this.renewBannerCertifiedUS = page.locator('div.notification.ribbon');
     this.bannerLink = page.locator('.notification p.body-m.action-area > a.con-button.outline');
     this.profileIconButton = page.locator('.feds-profile-button');
   }
 
   getBannerParagraphByIndex() {
+    return this.page.locator('.foreground.container.no-image .text .body-m:not(.action-area)');
+  }
+  
+  getBannerParagraphCertifiedUS() {
     return this.page.locator('.text .copy-wrap > p.body-m');
   }
+
 }

--- a/nala/blocks/banners/banners.test.js
+++ b/nala/blocks/banners/banners.test.js
@@ -157,9 +157,9 @@ test.describe('Validate banners', () => {
 
     await test.step('Verify renew banner', async () => {
       await bannersPage.profileIconButton.waitFor({ state: 'visible', timeout: 20000 });
-      const renewBanner = await bannersPage.renewBanner;
+      const renewBanner = await bannersPage.renewBannerCertifiedUS
       await expect(renewBanner).toBeVisible();
-      const firstParagraph = bannersPage.getBannerParagraphByIndex(data.paragraphIndex);
+      const firstParagraph = bannersPage.getBannerParagraphCertifiedUS(data.paragraphIndex);
       await expect(firstParagraph).toContainText(data.bannerText);
       const renewLink = await bannersPage.bannerLink;
       await expect(renewLink).toHaveText(data.renewButtonText);
@@ -182,9 +182,9 @@ test.describe('Validate banners', () => {
 
     await test.step('Verify renew banner', async () => {
       await bannersPage.profileIconButton.waitFor({ state: 'visible', timeout: 20000 });
-      const renewBanner = await bannersPage.renewBanner;
+      const renewBanner = await bannersPage.renewBannerCertifiedUS;
       await expect(renewBanner).toBeVisible();
-      const firstParagraph = bannersPage.getBannerParagraphByIndex(data.paragraphIndex);
+      const firstParagraph = bannersPage.getBannerParagraphCertifiedUS(data.paragraphIndex);
       await expect(firstParagraph).toContainText(data.bannerText);
       const renewLink = await bannersPage.bannerLink;
       await expect(renewLink).toHaveText(data.renewButtonText);


### PR DESCRIPTION
link for test: https:/fix-for-banners--dme-partners--adobecom.hlx.page/channelpartners/

Fix:
For tests under IDs 18 and 17, different locators are required for the banner than for other tests. I added a new locator that will search for the banner only for those two tests.