### PR TITLE
fixing tags on cards (search, logos)

### DIFF
--- a/edsdme/blocks/announcements/announcements.js
+++ b/edsdme/blocks/announcements/announcements.js
@@ -1,5 +1,5 @@
 import { getLibs, getCaasUrl } from '../../scripts/utils.js';
-import { getConfig, populateLocalizedTextFromListItems, localizationPromises } from '../utils/utils.js';
+import { getConfig, populateLocalizedTextFromPlaceholders } from '../utils/utils.js';
 import Announcements from './AnnouncementsCards.js';
 
 function declareAnnouncements() {
@@ -41,10 +41,9 @@ export default async function init(el) {
     '{{show-all}}': 'Show all',
   };
 
-  populateLocalizedTextFromListItems(el, localizedText);
+  populateLocalizedTextFromPlaceholders(localizedText);
 
   const deps = await Promise.all([
-    localizationPromises(localizedText, config),
     import(`${miloLibs}/features/spectrum-web-components/dist/theme.js`),
     import(`${miloLibs}/features/spectrum-web-components/dist/search.js`),
     import(`${miloLibs}/features/spectrum-web-components/dist/checkbox.js`),

--- a/edsdme/blocks/logos/logos.js
+++ b/edsdme/blocks/logos/logos.js
@@ -1,5 +1,5 @@
 import { getLibs } from '../../scripts/utils.js';
-import { getConfig, populateLocalizedTextFromListItems, localizationPromises } from '../utils/utils.js';
+import { getConfig, populateLocalizedTextFromPlaceholders } from '../utils/utils.js';
 import Logos from './LogosCards.js';
 
 function declareLogos() {
@@ -20,10 +20,9 @@ export default async function init(el) {
     '{{last-modified}}': 'Last modified',
   };
 
-  populateLocalizedTextFromListItems(el, localizedText);
+  populateLocalizedTextFromPlaceholders(localizedText);
 
   const deps = await Promise.all([
-    localizationPromises(localizedText, config),
     import(`${miloLibs}/features/spectrum-web-components/dist/theme.js`),
     import(`${miloLibs}/features/spectrum-web-components/dist/button.js`),
     import(`${miloLibs}/features/spectrum-web-components/dist/progress-circle.js`),

--- a/edsdme/blocks/pricelist/pricelist.js
+++ b/edsdme/blocks/pricelist/pricelist.js
@@ -2,8 +2,7 @@ import PricelistBlock from './PricelistBlock.js';
 import {
   getConfig,
   getRuntimeActionUrl,
-  localizationPromises,
-  populateLocalizedTextFromListItems,
+  populateLocalizedTextFromPlaceholders,
 } from '../utils/utils.js';
 import { getLibs } from '../../scripts/utils.js';
 
@@ -53,10 +52,9 @@ export default async function init(el) {
     '{{type}}': 'Type',
     '{{action}}': 'Action',
   };
-  populateLocalizedTextFromListItems(el, localizedText);
+  populateLocalizedTextFromPlaceholders(localizedText);
 
   const deps = await Promise.all([
-    localizationPromises(localizedText, config),
     import(`${miloLibs}/features/spectrum-web-components/dist/theme.js`),
     import(`${miloLibs}/features/spectrum-web-components/dist/search.js`),
     import(`${miloLibs}/features/spectrum-web-components/dist/checkbox.js`),

--- a/edsdme/blocks/search-full/search-full.js
+++ b/edsdme/blocks/search-full/search-full.js
@@ -1,5 +1,5 @@
 import { getLibs } from '../../scripts/utils.js';
-import { getConfig, populateLocalizedTextFromListItems, localizationPromises } from '../utils/utils.js';
+import { getConfig, populateLocalizedTextFromPlaceholders } from '../utils/utils.js';
 import Search from './SearchCards.js';
 
 function declareSearch() {
@@ -46,10 +46,9 @@ export default async function init(el) {
     '{{view-all-results}}': 'View all results',
   };
 
-  populateLocalizedTextFromListItems(el, localizedText);
+  populateLocalizedTextFromPlaceholders(localizedText);
 
   const deps = await Promise.all([
-    localizationPromises(localizedText, config),
     import(`${miloLibs}/features/spectrum-web-components/dist/theme.js`),
     import(`${miloLibs}/features/spectrum-web-components/dist/search.js`),
     import(`${miloLibs}/features/spectrum-web-components/dist/checkbox.js`),

--- a/edsdme/blocks/utils/utils.js
+++ b/edsdme/blocks/utils/utils.js
@@ -5,8 +5,6 @@ const miloLibs = setLibs('/libs');
 const { createTag, localizeLink, getConfig } = await import(`${miloLibs}/utils/utils.js`);
 
 export { createTag, localizeLink, getConfig };
-const { replaceText } = await import(`${miloLibs}/features/placeholders.js`);
-export { replaceText };
 
 export async function populateLocalizedTextFromPlaceholders(localizedText) {
   const { locales } = getConfig();

--- a/edsdme/blocks/utils/utils.js
+++ b/edsdme/blocks/utils/utils.js
@@ -8,23 +8,23 @@ export { createTag, localizeLink, getConfig };
 const { replaceText } = await import(`${miloLibs}/features/placeholders.js`);
 export { replaceText };
 
-export function populateLocalizedTextFromListItems(el, localizedText) {
-  const liList = Array.from(el.querySelectorAll('li'));
-  liList.forEach((liEl) => {
-    const liInnerText = liEl.innerText;
-    if (!liInnerText) return;
-    let liContent = liInnerText.trim().toLowerCase().replace(/ /g, '-');
-    if (liContent.endsWith('_default')) liContent = liContent.slice(0, -8);
-    localizedText[`{{${liContent}}}`] = liContent;
-  });
-}
-export async function localizationPromises(localizedText, config) {
-  return Promise.all(Object.keys(localizedText).map(async (key) => {
-    const value = await replaceText(key, config);
-    if (value.length) {
-      localizedText[key] = value;
+export async function populateLocalizedTextFromPlaceholders(localizedText) {
+  const { locales } = getConfig();
+  const locale = getLocale(locales);
+  const placeholderPath = `${locale.prefix}/edsdme/partners-shared/placeholders.json`;
+  const placeholderUrl = new URL(placeholderPath, window.location.origin);
+
+  const response = await fetch(placeholderUrl);
+  if (!response.ok) {
+    throw new Error(`Error message: ${response.statusText}`);
+  }
+
+  const jsonResponse = await response.json();
+  jsonResponse.data.forEach((pair) => {
+    if (pair.value) {
+      localizedText[`{{${pair.key}}}`] = pair.value;
     }
-  }));
+  });
 }
 
 export function getRuntimeActionUrl(action) {

--- a/edsdme/components/SearchCard.js
+++ b/edsdme/components/SearchCard.js
@@ -23,7 +23,8 @@ class SearchCard extends LitElement {
       (tag) => tag.key,
       (tag) => {
         const key = Object.values(tag)[0];
-        return html`<span class="card-tag">${this.localizedText[`{{${key}}}`] || key.replaceAll('-', ' ')}</span>`;
+        const localizedText = this.localizedText[`{{${key}}}`];
+        return localizedText ? html`<span class="card-tag">${localizedText}</span>` : '';
       },
     )}`;
   }

--- a/edsdme/scripts/utils.js
+++ b/edsdme/scripts/utils.js
@@ -393,13 +393,18 @@ export async function preloadResources(locales, miloLibs) {
     announcements: '"caas:adobe-partners/collections/announcements"',
     'announcements-preview': '"caas:adobe-partners/collections/announcements"',
   };
+  const blockWithPlaceholders = ['announcements', 'search-full', 'logos', 'pricelist'];
 
+  blockWithPlaceholders.forEach(async (item) => {
+    const el = document.querySelector(`.${item}`);
+    if (!el) return;
+    preloadPlaceholders(locale);
+  });
   Object.entries(cardBlocks).forEach(async ([key, value]) => {
     const el = document.querySelector(`.${key}`);
     if (!el) return;
 
     if (key !== 'announcements-preview') {
-      preloadPlaceholders(locale);
       preloadLit(miloLibs);
     }
 


### PR DESCRIPTION
tickets: [MWPW-165925](https://jira.corp.adobe.com/browse/MWPW-165925), [MWPW-165926](https://jira.corp.adobe.com/browse/MWPW-165926)

- changing logic for placeholders
- populating localizedText from placholders.json instead of list items from block
- display tag only if its translated
- added preload for placeholders on blocks that is used (search-full, logos, pricelists, announcements)
Note: we need to make sure that we have placholders file on every locale

testing urls:
https://mwpw-165925-fix-tags--dme-partners--adobecom.hlx.page/channelpartners/home/search/
https://mwpw-165925-fix-tags--dme-partners--adobecom.hlx.page/channelpartners/home/marketing/logos/