### PR TITLE
MWPW-167119 - channelpartner is broken on iOS15 on XCode simulator

### DIFF
--- a/edsdme/scripts/personalization.js
+++ b/edsdme/scripts/personalization.js
@@ -100,11 +100,11 @@ function processRenew(profile) {
 }
 
 function processGnavElements(elements) {
-  const regex = /(?<=\().*?(?=\))/g;
+  const regex = /\((.*?)\)/g;
   return elements.map((el) => {
-    const matches = el.textContent.match(regex);
-    if (!matches?.length) return {};
-    const match = matches[0];
+    const matches = [...el.textContent.matchAll(regex)];
+    if (!matches?.length || !matches[0][1]) return {};
+    const match = matches[0][1];
     el.textContent = el.textContent.replace(`(${match})`, '');
     const conditions = match.split(',').map((condition) => condition.trim());
     if (!conditions.length) return {};


### PR DESCRIPTION
https://jira.corp.adobe.com/browse/MWPW-167119

- replaces regex lookbehind with group capture
- lookbehind browser support: https://caniuse.com/?search=lookbehind (reason why this wasn't working on older versions of Safari)

Test URL:
https://MWPW-167119-regex-older-support--dme-partners--adobecom.hlx.page/channelpartners/home/