### PR TITLE
sign-in-tests-fix

### DIFF
--- a/nala/blocks/signin/signin.spec.js
+++ b/nala/blocks/signin/signin.spec.js
@@ -61,7 +61,7 @@ export default {
     {
       tcid: '5',
       name: '@login-direct-sign-in-from-program-page-non-member',
-      path: 'https://partners.stage.adobe.com/channelpartners/program/?georouting=off&martech=off',
+      path: 'https://partners.stage.adobe.com/channelpartners/?georouting=off&martech=off',
       tags: '@dme-signin @regression @login @circleCi',
       data: {
         partnerLevel: 'spp-platinum:',

--- a/nala/blocks/signin/signin.test.js
+++ b/nala/blocks/signin/signin.test.js
@@ -151,7 +151,13 @@ test.describe('MAPC sign in flow', () => {
           .toContain(`${feature.data.expectedRedirectedURL}`);
         await expect(signInButtonInt).toBeHidden();
         const joinNowButton = await newTabPage.joinNowButton;
-        await expect(joinNowButton).toBeVisible();
+        if (feature === features[5]) {
+          // Test 6 - Join In button visible in gnav
+          await expect(joinNowButton).toBeVisible();
+        } else if (feature === features[6]) {
+          // Test 7 - Join In button is not visible in gnav
+          await expect(joinNowButton).toBeHidden();
+        }
       });
     });
   });


### PR DESCRIPTION
URL for test: https://login-tests-fix--dme-partners--adobecom.hlx.page/channelpartners/

Updated signin' tests:

- @login-direct-sign-in-from-program-page-non-member removed program page from URL
- for @login-accessing-public-page-with-non-member-user-logged-in-to-adobe Join in button is not visible on the international home page so the test checks now that button is not visible.