### PR TITLE
update hosts to partnerspreview.adobe.com 

### DIFF
--- a/edsdme/scripts/utils.js
+++ b/edsdme/scripts/utils.js
@@ -54,6 +54,7 @@ export const prodHosts = [
   'main--dme-partners--adobecom.aem.page',
   'main--dme-partners--adobecom.aem.live',
   'partners.adobe.com',
+  'partnerspreview.adobe.com',
 ];
 
 /*

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -1,6 +1,6 @@
 {
   "previewHost": "main--dme-partners--adobecom.aem.page",
-  "liveHost": "main--dme-partners--adobecom.aem.live",
+  "liveHost": "partnerspreview.adobe.com",
   "plugins": [
     {
       "id": "library",


### PR DESCRIPTION
so authors can preview the full site without being signed in as a partner.
Testing-URL: https://dme-update-preview-host--dme-partners--adobecom.aem.live/channelpartners/