### PR TITLE
adding sidekick event listener for previewing and publishing 

### DIFF
--- a/edsdme/blocks/utils/utils.js
+++ b/edsdme/blocks/utils/utils.js
@@ -122,7 +122,7 @@ export async function sidekickListener(locales) {
       toast.variant = variant;
       toast.open = true;
       toast.dismissible = true;
-      toast.setAttribute('style', 'width: 300px');
+      toast.setAttribute('style', 'width: 320px');
       toast.textContent = message;
 
       theme.appendChild(toast);
@@ -135,6 +135,8 @@ export async function sidekickListener(locales) {
             const contentEl = shadow.querySelector('.content');
             if (contentEl) {
               contentEl.style.setProperty('word-break', 'break-word');
+              contentEl.style.setProperty('overflow-x', 'hidden');
+              contentEl.style.setProperty('max-height', '500px');
             }
           }
         });

--- a/edsdme/scripts/scripts.js
+++ b/edsdme/scripts/scripts.js
@@ -9,22 +9,16 @@ import {
   updateFooter,
   enableGeoPopup,
   PARTNER_LOGIN_QUERY,
+  prodHosts,
+  previewHost,
 } from './utils.js';
 import { rewriteLinks } from './rewriteLinks.js';
-
+import { sidekickListener } from '../blocks/utils/utils.js';
 // Add project-wide style path here.
 const STYLES = '/edsdme/styles/styles.css';
 
 // Use 'https://milo.adobe.com/libs' if you cannot map '/libs' to milo's origin.
 const LIBS = '/libs';
-
-const prodHosts = [
-  'main--dme-partners--adobecom.hlx.page',
-  'main--dme-partners--adobecom.hlx.live',
-  'main--dme-partners--adobecom.aem.page',
-  'main--dme-partners--adobecom.aem.live',
-  'partners.adobe.com',
-];
 
 const imsClientId = prodHosts.includes(window.location.host) ? 'MILO_PARTNERS_PROD' : 'MILO_PARTNERS_STAGE';
 
@@ -118,4 +112,7 @@ function setUpPage() {
   await loadArea();
   applyPagePersonalization();
   rewriteLinks(document);
+  if (previewHost.includes(window.location.host)) {
+    sidekickListener(CONFIG.locales);
+  }
 }());

--- a/edsdme/scripts/utils.js
+++ b/edsdme/scripts/utils.js
@@ -56,6 +56,7 @@ export const prodHosts = [
   'partners.adobe.com',
   'partnerspreview.adobe.com',
 ];
+export const previewHost = 'partnerspreview.adobe.com';
 
 /*
  * ------------------------------------------------------------

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -86,6 +86,21 @@
       "includePaths": [
         "**.docx**"
       ]
+    },
+    {
+      "containerId": "tools",
+      "title": "Publish to all sites",
+      "id": "publishtoallsites",
+      "event": "publishtoallsites",
+      "excludePaths": [
+        "/**"
+      ],
+      "includePaths": [
+        "/channelpartners/**"
+      ],
+      "environments": [
+        "live"
+      ]
     }
   ]
 }


### PR DESCRIPTION
adding sidekick event listener for previewing and publishing announcements and calling runtime action

removing prodHosts from scripts.js since its exported in utils.js

test url:
https://mwpw-172830-announcements--dme-partners--adobecom.aem.page/channelpartners/ 