### PR TITLE
Remove redundant profileIcon declaration in smoke.page.js

### DIFF
--- a/nala/blocks/smoke-test/smoke.page.js
+++ b/nala/blocks/smoke-test/smoke.page.js
@@ -128,7 +128,6 @@ export default class SmokeTest {
     await profileIcon.waitFor({ state: 'visible', timeout: 30000 });
 
     await this.page.waitForLoadState();
-    const { profileIcon } = this;
     await profileIcon.waitFor({ state: 'visible', timeout: 30000 });
 
     const cleanHref = href.endsWith('#') ? href.slice(0, -1) : href;


### PR DESCRIPTION
test URL: https://removed-profileIcon--dme-partners--adobecom.aem.page/channelpartners/