### PR TITLE
fix caas cache

### DIFF
--- a/edsdme/scripts/utils.js
+++ b/edsdme/scripts/utils.js
@@ -436,7 +436,7 @@ export function getCaasUrl(block) {
 
   const isPrpCollectionRelated = block.collectionTag.includes('caas:adobe-partners/collections/prp-collection') || block.collectionTag.includes('caas:adobe-partners/collections/marketing-resources');
   if ((isPrpCollectionRelated) && !isProd) {
-    domain = 'https://www.stage.adobe.com/chimera-api';
+    domain = 'https://14257-chimera-stage.adobeioruntime.net/api/v1/web/chimera-0.0.1';
   }
 
   const api = new URL(`${domain}/collection?originSelection=dme-partners&draft=false&debug=true&flatFile=false&expanded=true`);


### PR DESCRIPTION
test url: http://caas-cache-fix--dme-partners--adobecom.aem.live/channelpartners/