### PR TITLE
MWPW-193495 - double fired events

### DIFF
--- a/edsdme/blocks/pricelist/PricelistBlock.js
+++ b/edsdme/blocks/pricelist/PricelistBlock.js
@@ -134,18 +134,17 @@ export default class Pricelist extends PartnerCards {
                 ${this.getArbitraryValue(rowData.arbitrary, priceListKeyWords.MONTH)}
             </td>
             <td headers="download">
-                <sp-theme theme="spectrum" color="light" scale="medium">
-                    <sp-action-button
-                            size="m"
-                            href="${rowData.contentArea?.url}"
-                            download="${rowData.contentArea?.filename}"
-                            aria-label="${this.blockData.localizedText['{{download}}']}"
-                            @click=${(e) => { if (e.isTrusted) { e.preventDefault(); } }}
-                            daa-ll="${processTrackingLabels(this.blockData.localizedText['{{download}}'], getConfig(), 30)}">
-                        <sp-icon-download slot="icon"></sp-icon-download>
-                        ${this.blockData.localizedText['{{download}}']}
-                    </sp-action-button>
-                </sp-theme>
+              <div class="download-btn-wrapper">
+                <a class="download-btn"
+                   href="${rowData.contentArea?.url}"
+                   download="${rowData.contentArea?.filename}"
+                   aria-label="${this.blockData.localizedText['{{download}}']}"
+                   daa-ll="${processTrackingLabels(this.blockData.localizedText['{{download}}'], getConfig(), 30)}"
+                >
+                  <sp-icon-download slot="icon"></sp-icon-download>
+                  ${this.blockData.localizedText['{{download}}']}
+                </a>
+              </div>
             </td>
         </tr>`;
   }

--- a/edsdme/blocks/pricelist/pricelist.css
+++ b/edsdme/blocks/pricelist/pricelist.css
@@ -116,7 +116,7 @@ pricelist-block .download-btn {
   border: 1px solid #b1b1b1;
   border-radius: 4px;
   padding: 6px 10px;
-  background: white;
+  background: #fff;
   text-decoration: none;
   transition: background 0.2s ease, border-color 0.2s ease;
 }

--- a/edsdme/blocks/pricelist/pricelist.css
+++ b/edsdme/blocks/pricelist/pricelist.css
@@ -50,8 +50,11 @@ pricelist-block .table-container {
 
 pricelist-block tr td:nth-child(5),
 pricelist-block tr th:nth-child(5) {
+  width: 50%;
+}
+
+pricelist-block tr th:nth-child(5) {
     text-align: right;
-    width: 50%;
 }
 
 pricelist-block tr td:nth-child(1),
@@ -101,8 +104,34 @@ pricelist-block .partner-cards-content {
     width: 100%;
 }
 
+pricelist-block .download-btn-wrapper {
+  display: flex;
+  justify-content: flex-end;
+}
+
+pricelist-block .download-btn {
+  display: flex;
+  align-items: center;
+  color: inherit;
+  border: 1px solid #b1b1b1;
+  border-radius: 4px;
+  padding: 6px 10px;
+  background: white;
+  text-decoration: none;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+pricelist-block .download-btn:hover {
+  border-color: #909090;
+  background: #e6e6e6;
+}
+
 pricelist-block sp-icon-download {
-    color: #747474;
+  color: #747474;
+  width: 18px;
+  min-width: 18px;
+  height: 18px;
+  margin-right: 8px;
 }
 
 pricelist-block .partner-cards-header .partner-cards-sort-wrapper .filters-btn-mobile {

--- a/edsdme/blocks/pricelist/pricelist.js
+++ b/edsdme/blocks/pricelist/pricelist.js
@@ -68,7 +68,6 @@ export default async function init(el) {
     import(`${miloLibs}/features/spectrum-web-components/dist/button.js`),
     import(`${miloLibs}/features/spectrum-web-components/dist/field-label.js`),
     import(`${miloLibs}/features/spectrum-web-components/dist/progress-circle.js`),
-    import(`${miloLibs}/features/spectrum-web-components/dist/action-button.js`),
   ]);
 
   declarePricelist();

--- a/edsdme/blocks/search-full/search-full.js
+++ b/edsdme/blocks/search-full/search-full.js
@@ -61,7 +61,6 @@ export default async function init(el) {
     import(`${miloLibs}/features/spectrum-web-components/dist/checkbox.js`),
     import(`${miloLibs}/features/spectrum-web-components/dist/button.js`),
     import(`${miloLibs}/features/spectrum-web-components/dist/progress-circle.js`),
-    import(`${miloLibs}/features/spectrum-web-components/dist/action-button.js`),
     import(`${miloLibs}/features/spectrum-web-components/dist/icons-workflow.js`),
     import(`${miloLibs}/features/spectrum-web-components/dist/button-group.js`),
   ]);

--- a/edsdme/components/SearchCard.css
+++ b/edsdme/components/SearchCard.css
@@ -55,6 +55,35 @@
 .search-card .card-header .card-icons {
   z-index: 1;
   flex-shrink: 0;
+  display: flex;
+  height: 32px;
+  gap: 3px;
+}
+
+.search-card .card-header .card-icons .card-btn {
+  color: #222;
+  border: 1px solid #b1b1b1;
+  display: flex;
+  border-radius: 4px;
+  padding: 6px 11px;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.search-card .card-header .card-icons .card-btn:hover {
+  background: #e6e6e6;
+  border-color: #909090;
+}
+
+.search-card .card-header .card-icons .card-btn[aria-disabled="true"] {
+  color: #b1b1b1;
+  border-color: #e6e6e6;
+  background: #fff;
+  pointer-events: none;
+}
+
+.search-card .card-header .card-icons .card-btn .icon {
+  width: 18px;
+  height: 18px;
 }
 
 .search-card .card-content {

--- a/edsdme/components/SearchCard.css
+++ b/edsdme/components/SearchCard.css
@@ -62,6 +62,7 @@
 
 .search-card .card-header .card-icons .card-btn {
   color: #222;
+  background: #fff;
   border: 1px solid #b1b1b1;
   display: flex;
   border-radius: 4px;

--- a/edsdme/components/SearchCard.js
+++ b/edsdme/components/SearchCard.js
@@ -3,7 +3,7 @@ import { getConfig, replaceText } from '../blocks/utils/utils.js';
 
 const miloLibs = getLibs();
 const config = getConfig();
-const { html, repeat, LitElement, until } = await import(`${miloLibs}/deps/lit-all.min.js`);
+const { html, repeat, LitElement, until, nothing } = await import(`${miloLibs}/deps/lit-all.min.js`);
 const { processTrackingLabels } = await import(`${miloLibs}/martech/attributes.js`);
 
 class SearchCard extends LitElement {
@@ -61,29 +61,42 @@ class SearchCard extends LitElement {
 
   /* eslint-disable indent */
   render() {
+    const title = this.data.contentArea?.title !== 'card-metadata' ? this.data.contentArea?.title : '';
+    const trackingTitle = processTrackingLabels(title, getConfig(), 30);
+    const isDlDisabled = this.isDownloadDisabled(this.data.contentArea?.type);
+
     return html`
       <div class="search-card" @click=${(e) => this.toggleCard(e.currentTarget)}>
         <div class="card-header">
           <div class="card-title-wrapper">
             <span class="card-chevron-icon"></span>
             <div class="file-icon" style="background-image: url('/edsdme/img/icons/${this.getFileType(this.data.contentArea?.type)}.svg')"></div>
-            <span class="card-title">${this.data.contentArea?.title !== 'card-metadata' ? this.data.contentArea?.title : ''}</span>
+            <span class="card-title">${title}</span>
           </div>
           <div class="card-icons">
-            <sp-theme theme="spectrum" color="light" scale="medium">
-              <sp-action-button daa-ll="Download | ${processTrackingLabels(this.data.contentArea?.title !== 'card-metadata' ? this.data.contentArea?.title : '', getConfig(), 30)}" @click=${(e) => { e.stopPropagation(); if (e.isTrusted) { e.preventDefault(); } }} ?disabled=${this.isDownloadDisabled(this.data.contentArea?.type)} href="${this.data.contentArea?.url}" download="${this.data.contentArea?.title}" aria-label="${this.localizedText['{{download}}']}"><sp-icon-download /></sp-action-button>
+              <a class="card-btn"
+                 daa-ll=${`Download | ${trackingTitle}`}
+                 @click=${(e) => { e.stopPropagation(); }} 
+                 href=${isDlDisabled ? nothing : this.data.contentArea?.url}          
+                 download=${this.data.contentArea?.title}
+                 aria-label=${this.localizedText['{{download}}']}
+                 aria-disabled=${isDlDisabled}>
+                <sp-icon-download class="icon" />
+              </a>
               ${this.isPreviewEnabled(this.data.contentArea?.type)
                 ? html`
-                  <sp-action-button daa-ll="Preview | ${processTrackingLabels(this.data.contentArea?.title !== 'card-metadata' ? this.data.contentArea?.title : '', getConfig(), 30)}" @click=${(e) => { e.stopPropagation(); if (e.isTrusted) { e.preventDefault(); } }} href="${this.data.contentArea?.url}"
-                                    target="_blank" aria-label="${this.localizedText['{{open-in}}']}">
-                    <sp-icon-open-in/>
-                  </sp-action-button>`
+                  <a class="card-btn"
+                     daa-ll=${`Preview | ${trackingTitle}`}
+                     @click=${(e) => { e.stopPropagation(); }}
+                     href=${this.data.contentArea?.url}
+                     target="_blank" 
+                     aria-label=${this.localizedText['{{open-in}}']}
+                     aria-disabled=${false}>
+                    <sp-icon-open-in class="icon"/>
+                  </a>`
                 : html`
-                  <sp-action-button disabled selected aria-label="${this.localizedText['{{open-in-disabled}}']}">
-                    <sp-icon-open-in/>
-                  </sp-action-button>`
+                  <a class="card-btn" aria-disabled=${true} aria-label=${this.localizedText['{{open-in-disabled}}']}><sp-icon-open-in class="icon"/></a>`
               }
-            </sp-theme>
           </div>
         </div>
 

--- a/test/blocks/search-full/search-full.test.js
+++ b/test/blocks/search-full/search-full.test.js
@@ -216,7 +216,7 @@ describe('SearchCard Unit Tests', () => {
       const firstCard = searchCardsWrapper.querySelector('search-card');
       expect(firstCard.getAttribute('daa-lh')).to.equal(`Search Card 1 | ${cards[0].contentArea.title}`);
 
-      const singlePartnerCardBtn = firstCard.querySelector('sp-action-button');
+      const singlePartnerCardBtn = firstCard.querySelector('.card-btn');
       expect(singlePartnerCardBtn.getAttribute('daa-ll')).to.equal(`Download | ${cards[0].contentArea.title}`);
     });
 


### PR DESCRIPTION
**Test URL:** https://mwpw-193495-double-fired-e--dme-partners--adobecom.aem.live/channelpartners/

**Resolves:** https://jira.corp.adobe.com/browse/MWPW-193495

**NOTE1:** 
According to the Spectrum Action Button documentation, the `href` attribute and other link-related properties (`target`, `download`, `referrerpolicy`, `rel`) on `<sp-action-button>` are deprecated and will be removed in a future release.

According to the documentation: If we need to use the `href` attribute, we should use an `<a>` element instead. Using an `<a>` element resolves the current issue with double-fired events.

Documentation: https://opensource.adobe.com/spectrum-web-components/components/action-button/

**NOTE2:** 
Search card: 

- If the download button is disabled, the href attribute will not be render at all.
- Attribute ‘disabled’ doesn’t have an impact on <a> element, instead I used aria-disabled which also  Improves accessibility.
- Extracted repeated expressions into constants.