### PR TITLE
yukon-citations-improvments

### DIFF
--- a/edsdme/blocks/yukon-chat/utils.js
+++ b/edsdme/blocks/yukon-chat/utils.js
@@ -38,6 +38,9 @@ function removeCitations(text) {
   let cleaned = text.replace(/\[\^(\d+)\]/g, '[$1]');
   cleaned = cleaned.replace(/\(\d+\)/g, '');
 
+  // Remove individual footnote definition lines (e.g. \n[^1]: ...)
+  cleaned = cleaned.replace(/\n\[\^\d+\]:[^\n]*/g, '');
+
   // Remove Citations/References section and everything after
   const lines = cleaned.split('\n');
   let cutoffIndex = -1;
@@ -51,7 +54,7 @@ function removeCitations(text) {
       .replace(/_/g, '')
       .trim();
 
-    if (/^#{0,6}\s*(citations?|references?):?\s*$/i.test(plainLine)) {
+    if (/^#{0,6}\s*(citations?|references?|cited\s+sources?):?\s*$/i.test(plainLine)) {
       cutoffIndex = i;
       break;
     }


### PR DESCRIPTION
testing url: https://yukon-citations-improvments--dme-partners--adobecom.aem.live/channelpartners/ 
remove "cited sources" and everything afterwards as we do for "citations" and "references"

remove footnotes lines when starting with \n[^1]:

Note: while testing nothing is breaking, but couldnt catch the fix sicne not always yukon respon with these responses