### PR TITLE
reference footnote fix

### DIFF
--- a/edsdme/blocks/yukon-chat/utils.js
+++ b/edsdme/blocks/yukon-chat/utils.js
@@ -38,8 +38,8 @@ function removeCitations(text) {
   let cleaned = text.replace(/\[\^(\d+)\]/g, '[$1]');
   cleaned = cleaned.replace(/\(\d+\)/g, '');
 
-  // Remove individual footnote definition lines (e.g. \n[^1]: ...)
-  cleaned = cleaned.replace(/\n\[\^\d+\]:[^\n]*/g, '');
+  // Remove individual footnote definition lines (e.g. \n[1]: ...)
+  cleaned = cleaned.replace(/\n\[\d+\]:[^\n]*/g, '');
 
   // Remove Citations/References section and everything after
   const lines = cleaned.split('\n');


### PR DESCRIPTION
first clean ^ and then clean footnotes \n[1]:

testing url: https://reference-improve-fix--dme-partners--adobecom.aem.live/channelpartners/
