### PR TITLE
fixing format of user specialization 

### DIFF
--- a/edsdme/scripts/utils.js
+++ b/edsdme/scripts/utils.js
@@ -351,7 +351,7 @@ function preloadLit(miloLibs) {
 
 export function getPermissionSpecializations() {
   const permissionSpecializations = getPartnerCookieValue(getCurrentProgramType(), 'permissionspecializations');
-  return permissionSpecializations.toLowerCase();
+  return permissionSpecializations?.replace(/\s+/g, '-').toLowerCase() || '';
 }
 
 function getPartnerLevelParams(portal) {


### PR DESCRIPTION
rom cookie we get user specializations with space (substance elite) and on asset on CaaS we are sending with - (substance-elite)

added - to user specializations

Test url: https://mwpw-199133-specializations-fix--dme-partners--adobecom.aem.live/channelpartners/